### PR TITLE
Publish on release events

### DIFF
--- a/.github/workflows/publish-eslint-config.yml
+++ b/.github/workflows/publish-eslint-config.yml
@@ -1,19 +1,17 @@
-name: Publish @recidiviz/eslint-config to registry
+name: Publish tagged packages
 
 on:
-  push:
-    tags:
-      - eslint-config@*
-    branches:
-      - main
-
-defaults:
-  run:
-    working-directory: packages/eslint-config
+  release:
+    types: [published]
 
 jobs:
-  publish:
+  publish-eslint-config:
+    name: Publish eslint-config package
     runs-on: ubuntu-latest
+    if: ${{ startsWith(github.ref, 'refs/tags/eslint-config@') }}
+    defaults:
+      run:
+        working-directory: packages/eslint-config
     steps:
       - uses: actions/checkout@v2
       - name: Use Node 14


### PR DESCRIPTION
## Description of the change

The previous version of this workflow had an error due to my misunderstanding of Github workflow syntax (it would publish on every push to `main`, not only on tag pushes to `main` as I intended) and I didn't test it well enough to catch this. (The good news is that the job itself worked fine and the package was published correctly, which was what I intended to do immediately after merging the last PR anyway, so no harm done!)

The better approach seems to be to use the `release` event instead and move the tag-check condition into the job definition. This is also nice because we can add additional publish jobs to the same workflow as necessary. 

I tested this locally with [act](https://github.com/nektos/act) to verify that the job runs or does not runs as expected based on the tag present at HEAD.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

part of https://github.com/Recidiviz/recidiviz-data/issues/6719

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
