### PR TITLE
Make sure that we run yarn build when publishing

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -49,6 +49,8 @@ jobs:
         with:
           working-directory: packages/design-system
           install-command: yarn --frozen-lockfile
+      - name: Yarn build
+        run: yarn build
       - name: Publish
         run: npm publish --verbose --access public
         env:

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recidiviz/design-system",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "UI components and styles for Recidiviz web products.",
   "author": "Recidiviz <team@recidiviz.org>",
   "license": "GPL-3.0-only",


### PR DESCRIPTION
## Description of the change

We need to run `yarn build` when deploying the `design-system` package. Currently the deployed package just has a `package.json` and a `README.md` in it.

Going to follow-up by immediately publishing.

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [X] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

N/A

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [ ] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
