### PR TITLE
Add error page

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recidiviz/design-system",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "UI components and styles for Recidiviz web products.",
   "author": "Recidiviz <team@recidiviz.org>",
   "license": "GPL-3.0-only",

--- a/packages/design-system/src/components/ErrorPage/ErrorPage.stories.tsx
+++ b/packages/design-system/src/components/ErrorPage/ErrorPage.stories.tsx
@@ -55,7 +55,7 @@ VerifyEmailPage.args = {
       <p>
         If you have reached this page by mistake, please try to log in again. If
         you are still having trouble, please reach out to{" "}
-        <Link href="mailto:web-support@recidiviz.org?subject=Trouble logging into Case Triage">
+        <Link href="mailto:web-support@recidiviz.org?subject=Trouble logging in">
           Recidiviz Support
         </Link>
         .

--- a/packages/design-system/src/components/ErrorPage/ErrorPage.stories.tsx
+++ b/packages/design-system/src/components/ErrorPage/ErrorPage.stories.tsx
@@ -1,0 +1,80 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2020 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+import * as React from "react";
+import { Story, Meta } from "@storybook/react";
+import styled from "styled-components/macro";
+import { rem } from "polished";
+
+import { ErrorPageProps, ErrorPage } from "./ErrorPage";
+
+import { Button } from "../Button/Button";
+import { Link } from "../Typography/Link";
+import { spacing } from "../../styles";
+
+export default {
+  title: "Design System/Pages/ErrorPage",
+  component: ErrorPage,
+  parameters: {
+    layout: "centered",
+  },
+} as Meta;
+
+const Template: Story<ErrorPageProps> = ({ headerText, children }) => (
+  <ErrorPage headerText={headerText}>{children}</ErrorPage>
+);
+
+const ActionButton = styled(Button)`
+  margin: ${rem(spacing.xl)} 0;
+`;
+
+export const VerifyEmailPage = Template.bind({});
+VerifyEmailPage.args = {
+  headerText: "Please verify your email.",
+  children: (
+    <>
+      <p>
+        If you have just signed up for an account, please check your inbox for
+        an email asking you to verify your email address. After you click the
+        verification button or link in that email, you can reach the home page
+        below.
+      </p>
+      <p>
+        If you have reached this page by mistake, please try to log in again. If
+        you are still having trouble, please reach out to{" "}
+        <Link href="mailto:web-support@recidiviz.org?subject=Trouble logging into Case Triage">
+          Recidiviz Support
+        </Link>
+        .
+      </p>
+      <ActionButton kind="secondary">Back to Home</ActionButton>
+    </>
+  ),
+};
+
+export const UnauthorizedPage = Template.bind({});
+UnauthorizedPage.args = {
+  headerText: "Thank you for your interest in Recidiviz.",
+  children: (
+    <p>
+      This page is currently unavailable for your account. Please reach out to{" "}
+      <Link href="mailto:web-support@recidiviz.org?subject=Access to Recidiviz app">
+        Recidiviz Support
+      </Link>{" "}
+      with any questions.
+    </p>
+  ),
+};

--- a/packages/design-system/src/components/ErrorPage/ErrorPage.styles.tsx
+++ b/packages/design-system/src/components/ErrorPage/ErrorPage.styles.tsx
@@ -1,0 +1,45 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2020 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+import styled from "styled-components";
+import { rem } from "polished";
+import { fonts, spacing } from "../../styles";
+
+export const OuterErrorPageContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+`;
+
+export const InnerErrorPageContainer = styled.div`
+  width: ${rem(700)};
+`;
+
+export const ErrorPageHeader = styled.h1`
+  font-family: ${fonts.heading};
+  font-weight: normal;
+  font-style: normal;
+  font-size: ${rem(34)};
+
+  margin: ${rem(spacing.xl)} 0;
+`;
+
+export const ErrorPageBody = styled.div`
+  font-family: ${fonts.body};
+  font-size: ${rem(19)};
+  line-height: ${rem(32)};
+`;

--- a/packages/design-system/src/components/ErrorPage/ErrorPage.tsx
+++ b/packages/design-system/src/components/ErrorPage/ErrorPage.tsx
@@ -37,7 +37,7 @@ export const ErrorPage = ({
   return (
     <OuterErrorPageContainer>
       <InnerErrorPageContainer>
-        <img src={Assets.LOGO} alt="Recidiviz - Case Triage" />
+        <img src={Assets.LOGO} alt="Recidiviz" />
         <ErrorPageHeader>{headerText}</ErrorPageHeader>
         <ErrorPageBody>{children}</ErrorPageBody>
       </InnerErrorPageContainer>

--- a/packages/design-system/src/components/ErrorPage/ErrorPage.tsx
+++ b/packages/design-system/src/components/ErrorPage/ErrorPage.tsx
@@ -1,0 +1,46 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2020 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+import * as React from "react";
+
+import Assets from "../../assets";
+import {
+  ErrorPageBody,
+  ErrorPageHeader,
+  InnerErrorPageContainer,
+  OuterErrorPageContainer,
+} from "./ErrorPage.styles";
+
+export interface ErrorPageProps {
+  headerText: string;
+
+  children: React.ReactNode;
+}
+
+export const ErrorPage = ({
+  headerText,
+  children,
+}: ErrorPageProps): JSX.Element => {
+  return (
+    <OuterErrorPageContainer>
+      <InnerErrorPageContainer>
+        <img src={Assets.LOGO} alt="Recidiviz - Case Triage" />
+        <ErrorPageHeader>{headerText}</ErrorPageHeader>
+        <ErrorPageBody>{children}</ErrorPageBody>
+      </InnerErrorPageContainer>
+    </OuterErrorPageContainer>
+  );
+};

--- a/packages/design-system/src/index.tsx
+++ b/packages/design-system/src/index.tsx
@@ -17,6 +17,7 @@
 import { GlobalStyle } from "./styles/GlobalStyle";
 import { Button, ButtonKind, ButtonProps } from "./components/Button/Button";
 import { Card, CardSection } from "./components/Card/Card";
+import { ErrorPage } from "./components/ErrorPage/ErrorPage";
 import { Header } from "./components/Header/Header";
 import { Icon } from "./components/Icon/Icon";
 import { IconSVG } from "./components/Icon/IconSVG";
@@ -42,8 +43,7 @@ export {
   Button,
   Card,
   CardSection,
-  TitleXXL,
-  TitleXL,
+  ErrorPage,
   H1,
   H2,
   H3,
@@ -58,6 +58,8 @@ export {
   Need,
   NeedState,
   Search,
+  TitleXL,
+  TitleXXL,
   fonts,
   palette,
   spacing,


### PR DESCRIPTION
## Description of the change

Adds an `ErrorPage` wrapper that can be used across apps to unify our error pages. In storybook, there are two examples that will be pulled into Case Triage immediately.

![image](https://user-images.githubusercontent.com/993682/116154608-def83800-a6b6-11eb-9591-aedfe865abed.png)


## Type of change

- [X] New feature (non-breaking change that adds functionality)

## Related issues

Closes #12 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [X] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
