### PR TITLE
Add `Dropdown` component

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recidiviz/design-system",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "UI components and styles for Recidiviz web products.",
   "author": "Recidiviz <team@recidiviz.org>",
   "license": "GPL-3.0-only",

--- a/packages/design-system/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.stories.tsx
@@ -1,0 +1,70 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2020 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+import * as React from "react";
+import { Story, Meta } from "@storybook/react";
+import Dropdown from "./Dropdown";
+import Toast, { ToastProvider, useToasts } from "../Toast/Toast";
+
+export default {
+  title: "Design System/Atoms/ButtonDropdown",
+  component: Dropdown.Toggle,
+  argTypes: {
+    kind: {
+      control: {
+        type: "radio",
+        options: ["primary", "secondary", "link"],
+      },
+    },
+  },
+  decorators: [
+    (BaseStory) => (
+      <ToastProvider>
+        <BaseStory />
+      </ToastProvider>
+    ),
+  ],
+} as Meta;
+
+const Template: Story = ({ children, kind, disabled, onClick }) => {
+  const { addToast } = useToasts();
+
+  return (
+    <>
+      <button type="button" style={{ margin: 10 }}>
+        other focusable element
+      </button>
+      <Dropdown>
+        <Dropdown.Toggle label="Report an issue with this case" />
+        <Dropdown.Menu>
+          <Dropdown.MenuItem
+            label="Person is not in caseload"
+            onClick={() => addToast("Caseload clicked")}
+          />
+          <Dropdown.MenuItem
+            label="Person in custody"
+            onClick={() => addToast("Custody clicked")}
+          />
+        </Dropdown.Menu>
+      </Dropdown>
+    </>
+  );
+};
+
+export const PrimaryButton = Template.bind({});
+PrimaryButton.args = {
+  children: "Add to Calendar",
+};

--- a/packages/design-system/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.stories.tsx
@@ -17,19 +17,11 @@
 import * as React from "react";
 import { Story, Meta } from "@storybook/react";
 import Dropdown from "./Dropdown";
-import Toast, { ToastProvider, useToasts } from "../Toast/Toast";
+import { ToastProvider, useToasts } from "../Toast/Toast";
 
 export default {
   title: "Design System/Atoms/ButtonDropdown",
-  component: Dropdown.Toggle,
-  argTypes: {
-    kind: {
-      control: {
-        type: "radio",
-        options: ["primary", "secondary", "link"],
-      },
-    },
-  },
+  component: Dropdown,
   decorators: [
     (BaseStory) => (
       <ToastProvider>

--- a/packages/design-system/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.stories.tsx
@@ -56,7 +56,4 @@ const Template: Story = ({ children, kind, disabled, onClick }) => {
   );
 };
 
-export const PrimaryButton = Template.bind({});
-PrimaryButton.args = {
-  children: "Add to Calendar",
-};
+export const DropdownStory = Template.bind({});

--- a/packages/design-system/src/components/Dropdown/Dropdown.styles.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.styles.tsx
@@ -96,7 +96,7 @@ export const MenuElement = styled.div.attrs({
     css`
       z-index: 1;
       opacity: 1;
-      pointer-events: auto;
+      pointer-events: all;
       transform: translateY(0);
     `}
 `;

--- a/packages/design-system/src/components/Dropdown/Dropdown.styles.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.styles.tsx
@@ -62,7 +62,8 @@ export const MenuItemElement = styled.button.attrs({
   }
 `;
 
-interface MenuElementProps {
+export interface MenuElementProps {
+  alignment?: "left" | "right";
   shown: boolean;
 }
 
@@ -75,7 +76,7 @@ export const MenuElement = styled.div.attrs({
   min-width: 193px;
   padding: 0;
   margin-top: ${rem(spacing.xs)};
-  right: 0;
+  ${(props: MenuElementProps) => props.alignment || "left"}: 0;
 
   background: ${palette.marble1};
   box-shadow: 0px 15px 40px rgba(53, 83, 98, 0.3),
@@ -113,8 +114,8 @@ export const ToggleElement = styled.button.attrs({
   position: relative;
   background: white;
   cursor: pointer;
-
-  width: ${rem(32)};
+  color: ${palette.pine4};
+  min-width: ${rem(32)};
   height: ${rem(32)};
   min-height: initial;
   min-width: initial;
@@ -132,6 +133,8 @@ export const ToggleElement = styled.button.attrs({
     props.shown &&
     css`
       background-color: ${palette.pine4};
+      color: white;
+
       &:hover {
         background-color: ${palette.pine4};
       }

--- a/packages/design-system/src/components/Dropdown/Dropdown.styles.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.styles.tsx
@@ -1,0 +1,150 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2020 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+import { rem } from "polished";
+import styled, { css } from "styled-components";
+import { palette, spacing } from "../../styles";
+
+export const MenuItemElement = styled.button.attrs({
+  type: "button",
+  role: "menuitem",
+})`
+  color: ${palette.pine3};
+  list-style: none;
+  height: ${rem(32)};
+  line-height: ${rem(32)};
+  padding: 0 ${rem(spacing.md)};
+  transition: color, background-color;
+  transition-easing: ease-in-out;
+  transition-duration: 0.1s;
+  background-color: white;
+  border: none;
+  width: 100%;
+  text-align: left;
+  white-space: nowrap;
+
+  &:focus {
+    outline: none;
+    color: ${palette.white};
+    background-color: ${palette.signal.links};
+    cursor: pointer;
+  }
+
+  &:active {
+    background-color: ${palette.pine4};
+  }
+
+  &:first-child {
+    margin-top: ${rem(spacing.sm)};
+  }
+
+  &:last-child {
+    margin-bottom: ${rem(spacing.sm)};
+  }
+
+  &:first-child:last-child {
+    margin-top: 0;
+    margin-bottom: 0;
+    border-radius: 8px;
+  }
+`;
+
+interface MenuElementProps {
+  shown: boolean;
+}
+
+export const MenuElement = styled.div.attrs({
+  role: "menubar",
+})<MenuElementProps>`
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  min-width: 193px;
+  padding: 0;
+  margin-top: ${rem(spacing.xs)};
+  right: 0;
+
+  background: ${palette.marble1};
+  box-shadow: 0px 15px 40px rgba(53, 83, 98, 0.3),
+    inset 0px -1px 1px rgba(19, 44, 82, 0.2);
+  border-radius: 8px;
+  font-size: ${rem(14)};
+
+  transition: 0.15s ease-in-out;
+  transition-property: opacity, transform;
+
+  z-index: 0;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-25%);
+
+  ${(props: MenuElementProps) =>
+    props.shown &&
+    css`
+      z-index: 1;
+      opacity: 1;
+      pointer-events: auto;
+      transform: translateY(0);
+    `}
+`;
+
+interface ToggleElementProps {
+  borderless?: boolean;
+  shown: boolean;
+}
+
+export const ToggleElement = styled.button.attrs({
+  type: "button",
+})<ToggleElementProps>`
+  padding: ${rem(spacing.sm)};
+  position: relative;
+  background: white;
+  cursor: pointer;
+
+  width: ${rem(32)};
+  height: ${rem(32)};
+  min-height: initial;
+  min-width: initial;
+  margin: 0;
+
+  border: 1px solid ${palette.slate30};
+  box-sizing: border-box;
+  border-radius: 4px;
+
+  &:hover {
+    border-color: ${palette.signal.links};
+  }
+
+  ${(props: ToggleElementProps) =>
+    props.shown &&
+    css`
+      background-color: ${palette.pine4};
+      &:hover {
+        background-color: ${palette.pine4};
+      }
+    `}
+
+  ${(props: ToggleElementProps) =>
+    props.borderless &&
+    css`
+      border-width: 0;
+    `}
+`;
+
+export const DropdownElement = styled.div`
+  display: inline-block;
+  position: relative;
+`;

--- a/packages/design-system/src/components/Dropdown/Dropdown.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.tsx
@@ -1,0 +1,49 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2020 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+import * as React from "react";
+import { useRef, useState } from "react";
+import { DropdownElement } from "./Dropdown.styles";
+import DropdownFocusManager from "./DropdownFocusManager";
+import DropdownContext from "./DropdownContext";
+import Menu from "./DropdownMenu";
+import MenuItem from "./DropdownMenuItem";
+import Toggle from "./DropdownToggle";
+
+interface DropdownProps {
+  children: JSX.Element | JSX.Element[];
+  className?: string;
+}
+
+const Dropdown = ({ children, className }: DropdownProps): JSX.Element => {
+  const ref = useRef(null);
+  const [focusManager] = useState(new DropdownFocusManager(ref));
+  const [shown, setShown] = useState(false);
+
+  return (
+    <DropdownContext.Provider value={{ focusManager, shown, setShown }}>
+      <DropdownElement className={className} ref={ref}>
+        {children}
+      </DropdownElement>
+    </DropdownContext.Provider>
+  );
+};
+
+Dropdown.Menu = Menu;
+Dropdown.MenuItem = MenuItem;
+Dropdown.Toggle = Toggle;
+
+export default Dropdown;

--- a/packages/design-system/src/components/Dropdown/DropdownContext.ts
+++ b/packages/design-system/src/components/Dropdown/DropdownContext.ts
@@ -14,17 +14,19 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
-import { MouseEventHandler, ReactChild } from "react";
+import * as React from "react";
+import DropdownFocusManager from "./DropdownFocusManager";
 
-export type ButtonKind = "primary" | "secondary" | "link";
-
-export interface ButtonProps {
-  children: ReactChild | ReactChild[];
-
-  className?: string;
-
-  kind?: ButtonKind;
-  disabled?: boolean;
-
-  onClick?: MouseEventHandler<HTMLButtonElement>;
+interface DropdownContextInterface {
+  shown: boolean;
+  setShown(shown: boolean): void;
+  focusManager: DropdownFocusManager;
 }
+
+const DropdownContext = React.createContext<DropdownContextInterface>({
+  shown: false,
+  setShown: (shown: boolean) => null,
+  focusManager: new DropdownFocusManager(null),
+});
+
+export default DropdownContext;

--- a/packages/design-system/src/components/Dropdown/DropdownFocusManager.ts
+++ b/packages/design-system/src/components/Dropdown/DropdownFocusManager.ts
@@ -1,0 +1,70 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2020 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+import * as React from "react";
+import { MenuItemElement, ToggleElement } from "./Dropdown.styles";
+
+class DropdownFocusManager {
+  dropdown: React.RefObject<HTMLElement> | null;
+
+  constructor(dropdown: React.RefObject<HTMLElement> | null) {
+    this.dropdown = dropdown;
+  }
+
+  querySelector<T>(selector: string): T | null {
+    const element = this.dropdown?.current?.querySelector(selector);
+
+    if (element) {
+      return (element as unknown) as T;
+    }
+
+    return null;
+  }
+
+  focusFirstItem(): void {
+    this.querySelector<HTMLButtonElement>(
+      `${MenuItemElement}:first-child`
+    )?.focus();
+  }
+
+  focusToggle(): void {
+    this.querySelector<HTMLButtonElement>(`${ToggleElement}`)?.focus();
+  }
+
+  focusNextItem(): void {
+    // Selects the focused menu item's next sibling, otherwise wrap to the first
+    const focused = this.querySelector<HTMLButtonElement>(
+      `${MenuItemElement}:focus`
+    );
+
+    const previous =
+      focused?.nextElementSibling || focused?.parentElement?.firstElementChild;
+    (previous as HTMLButtonElement).focus();
+  }
+
+  focusPreviousItem(): void {
+    // Selects the focused menu item's previous sibling, otherwise wrap to the last
+    const focused = this.querySelector<HTMLButtonElement>(
+      `${MenuItemElement}:focus`
+    );
+    const previous =
+      focused?.previousElementSibling ||
+      focused?.parentElement?.lastElementChild;
+    (previous as HTMLButtonElement).focus();
+  }
+}
+
+export default DropdownFocusManager;

--- a/packages/design-system/src/components/Dropdown/DropdownMenu.tsx
+++ b/packages/design-system/src/components/Dropdown/DropdownMenu.tsx
@@ -1,0 +1,84 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2020 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+import * as React from "react";
+import { KeyboardEventHandler, useContext } from "react";
+import { MenuElement, MenuItemElement, ToggleElement } from "./Dropdown.styles";
+import DropdownContext from "./DropdownContext";
+
+interface MenuProps {
+  className?: string;
+  children?: React.ReactChild | React.ReactChildren | JSX.Element[];
+}
+
+const Menu = ({ className, children }: MenuProps): JSX.Element => {
+  const { focusManager, shown, setShown } = useContext(DropdownContext);
+  const onKeyPress: KeyboardEventHandler<HTMLDivElement> = (
+    event: React.KeyboardEvent<HTMLDivElement>
+  ) => {
+    switch (event.key) {
+      case "Down":
+      case "ArrowDown":
+      case "Tab":
+        event.preventDefault();
+        focusManager.focusNextItem();
+        break;
+      case "Up":
+      case "ArrowUp":
+        event.preventDefault();
+        focusManager.focusPreviousItem();
+        break;
+      case "Esc":
+      case "Escape":
+        event.preventDefault();
+        setShown(false);
+        focusManager.focusToggle();
+        break;
+      default:
+        break;
+    }
+  };
+
+  const onFocusOut: React.FocusEventHandler<HTMLDivElement> = (
+    event: React.FocusEvent<HTMLDivElement>
+  ) => {
+    // Blurred from the menu, but is not focusing a different element
+    if (event.relatedTarget === null) {
+      setShown(false);
+      focusManager.focusToggle();
+      return;
+    }
+
+    const related = event.relatedTarget as HTMLElement;
+    // Focus has left the menu, don't re-focus toggle
+    if (!related.matches(`${MenuItemElement}, ${ToggleElement}`)) {
+      setShown(false);
+    }
+  };
+
+  return (
+    <MenuElement
+      className={className}
+      onKeyDown={onKeyPress}
+      onBlur={onFocusOut}
+      shown={shown}
+    >
+      {children}
+    </MenuElement>
+  );
+};
+
+export default Menu;

--- a/packages/design-system/src/components/Dropdown/DropdownMenu.tsx
+++ b/packages/design-system/src/components/Dropdown/DropdownMenu.tsx
@@ -52,30 +52,23 @@ const Menu = ({ className, children }: MenuProps): JSX.Element => {
     }
   };
 
-  const onFocusOut: React.FocusEventHandler<HTMLDivElement> = (
-    event: React.FocusEvent<HTMLDivElement>
-  ) => {
-    // Blurred from the menu, but is not focusing a different element
-    if (event.relatedTarget === null) {
-      setShown(false);
-      focusManager.focusToggle();
-      return;
-    }
+  React.useEffect(() => {
+    const handleFocus = (event: FocusEvent) => {
+      const target = event.target as HTMLElement;
 
-    const related = event.relatedTarget as HTMLElement;
-    // Focus has left the menu, don't re-focus toggle
-    if (!related.matches(`${MenuItemElement}, ${ToggleElement}`)) {
-      setShown(false);
-    }
-  };
+      if (!focusManager.dropdown?.current?.contains(target)) {
+        setShown(false);
+      }
+    };
+
+    document.addEventListener("click", handleFocus);
+    return () => {
+      document.removeEventListener("click", handleFocus);
+    };
+  });
 
   return (
-    <MenuElement
-      className={className}
-      onKeyDown={onKeyPress}
-      onBlur={onFocusOut}
-      shown={shown}
-    >
+    <MenuElement className={className} onKeyDown={onKeyPress} shown={shown}>
       {children}
     </MenuElement>
   );

--- a/packages/design-system/src/components/Dropdown/DropdownMenu.tsx
+++ b/packages/design-system/src/components/Dropdown/DropdownMenu.tsx
@@ -16,15 +16,16 @@
 // =============================================================================
 import * as React from "react";
 import { KeyboardEventHandler, useContext } from "react";
-import { MenuElement, MenuItemElement, ToggleElement } from "./Dropdown.styles";
+import { MenuElement } from "./Dropdown.styles";
 import DropdownContext from "./DropdownContext";
 
 export interface MenuProps {
+  alignment?: "left" | "right";
   className?: string;
   children?: React.ReactChild | React.ReactChildren | JSX.Element[];
 }
 
-const Menu = ({ className, children }: MenuProps): JSX.Element => {
+const Menu = ({ alignment, className, children }: MenuProps): JSX.Element => {
   const { focusManager, shown, setShown } = useContext(DropdownContext);
   const onKeyPress: KeyboardEventHandler<HTMLDivElement> = (
     event: React.KeyboardEvent<HTMLDivElement>
@@ -62,13 +63,19 @@ const Menu = ({ className, children }: MenuProps): JSX.Element => {
     };
 
     document.addEventListener("click", handleFocus);
+
     return () => {
       document.removeEventListener("click", handleFocus);
     };
   });
 
   return (
-    <MenuElement className={className} onKeyDown={onKeyPress} shown={shown}>
+    <MenuElement
+      alignment={alignment}
+      className={className}
+      onKeyDown={onKeyPress}
+      shown={shown}
+    >
       {children}
     </MenuElement>
   );

--- a/packages/design-system/src/components/Dropdown/DropdownMenu.tsx
+++ b/packages/design-system/src/components/Dropdown/DropdownMenu.tsx
@@ -19,7 +19,7 @@ import { KeyboardEventHandler, useContext } from "react";
 import { MenuElement, MenuItemElement, ToggleElement } from "./Dropdown.styles";
 import DropdownContext from "./DropdownContext";
 
-interface MenuProps {
+export interface MenuProps {
   className?: string;
   children?: React.ReactChild | React.ReactChildren | JSX.Element[];
 }

--- a/packages/design-system/src/components/Dropdown/DropdownMenuItem.tsx
+++ b/packages/design-system/src/components/Dropdown/DropdownMenuItem.tsx
@@ -1,0 +1,62 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2020 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+import { useContext, useEffect, useRef } from "react";
+import * as React from "react";
+import { MenuItemElement } from "./Dropdown.styles";
+import DropdownContext from "./DropdownContext";
+
+interface MenuItemProps {
+  className?: string;
+  label: string;
+  onClick: React.MouseEventHandler<HTMLButtonElement>;
+}
+
+const MenuItem = ({
+  className,
+  label,
+  onClick,
+}: MenuItemProps): JSX.Element => {
+  const { focusManager, shown, setShown } = useContext(DropdownContext);
+  const ref = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    focusManager.focusFirstItem();
+  }, [shown, focusManager]);
+
+  const onMouseEnter = (event: React.MouseEvent<HTMLButtonElement>) => {
+    ref.current?.focus();
+  };
+
+  return (
+    <MenuItemElement
+      className={className}
+      ref={ref}
+      onMouseEnter={onMouseEnter}
+      onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+        onClick(event);
+        setShown(false);
+        focusManager.focusToggle();
+      }}
+      disabled={!shown}
+      tabIndex={shown ? 0 : -1}
+    >
+      {label}
+    </MenuItemElement>
+  );
+};
+
+export default MenuItem;

--- a/packages/design-system/src/components/Dropdown/DropdownMenuItem.tsx
+++ b/packages/design-system/src/components/Dropdown/DropdownMenuItem.tsx
@@ -19,7 +19,7 @@ import * as React from "react";
 import { MenuItemElement } from "./Dropdown.styles";
 import DropdownContext from "./DropdownContext";
 
-interface MenuItemProps {
+export interface MenuItemProps {
   className?: string;
   label: string;
   onClick: React.MouseEventHandler<HTMLButtonElement>;

--- a/packages/design-system/src/components/Dropdown/DropdownToggle.tsx
+++ b/packages/design-system/src/components/Dropdown/DropdownToggle.tsx
@@ -23,12 +23,14 @@ import { palette } from "../../styles";
 
 export interface ToggleProps {
   borderless?: boolean;
+  children?: React.ReactChild | null;
   className?: string;
   label?: string;
   icon?: IconSVGMap[keyof IconSVGMap];
 }
 
 const Toggle = ({
+  children,
   className,
   borderless = false,
   icon = IconSVG.DownChevron,
@@ -51,6 +53,7 @@ const Toggle = ({
       aria-haspopup="menu"
       aria-expanded={shown}
     >
+      {children}
       <Icon
         kind={icon}
         size={borderless ? 14 : 8}

--- a/packages/design-system/src/components/Dropdown/DropdownToggle.tsx
+++ b/packages/design-system/src/components/Dropdown/DropdownToggle.tsx
@@ -1,0 +1,63 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2020 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+import * as React from "react";
+import { IconSVG, IconSVGMap } from "../Icon/IconSVG";
+import DropdownContext from "./DropdownContext";
+import { ToggleElement } from "./Dropdown.styles";
+import { Icon } from "../Icon/Icon";
+import { palette } from "../../styles";
+
+interface ToggleProps {
+  borderless?: boolean;
+  className?: string;
+  label?: string;
+  icon?: IconSVGMap[keyof IconSVGMap];
+}
+
+const Toggle = ({
+  className,
+  borderless = false,
+  icon = IconSVG.DownChevron,
+  label,
+}: ToggleProps): JSX.Element => {
+  const { shown, setShown } = React.useContext(DropdownContext);
+
+  return (
+    <ToggleElement
+      className={className}
+      onClick={() => setShown(!shown)}
+      onKeyPress={(event) => {
+        if (event.key === "Down" || event.key === "ArrowDown") {
+          setShown(true);
+        }
+      }}
+      borderless={borderless}
+      shown={shown}
+      aria-label={label}
+      aria-haspopup="menu"
+      aria-expanded={shown}
+    >
+      <Icon
+        kind={icon}
+        size={borderless ? 14 : 8}
+        fill={shown ? palette.marble1 : palette.signal.links}
+      />
+    </ToggleElement>
+  );
+};
+
+export default Toggle;

--- a/packages/design-system/src/components/Dropdown/DropdownToggle.tsx
+++ b/packages/design-system/src/components/Dropdown/DropdownToggle.tsx
@@ -21,7 +21,7 @@ import { ToggleElement } from "./Dropdown.styles";
 import { Icon } from "../Icon/Icon";
 import { palette } from "../../styles";
 
-interface ToggleProps {
+export interface ToggleProps {
   borderless?: boolean;
   className?: string;
   label?: string;

--- a/packages/design-system/src/components/Dropdown/index.ts
+++ b/packages/design-system/src/components/Dropdown/index.ts
@@ -14,17 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
-import { MouseEventHandler, ReactChild } from "react";
+import Dropdown from "./Dropdown";
 
-export type ButtonKind = "primary" | "secondary" | "link";
-
-export interface ButtonProps {
-  children: ReactChild | ReactChild[];
-
-  className?: string;
-
-  kind?: ButtonKind;
-  disabled?: boolean;
-
-  onClick?: MouseEventHandler<HTMLButtonElement>;
-}
+export default Dropdown;

--- a/packages/design-system/src/components/Icon/IconSVG.tsx
+++ b/packages/design-system/src/components/Icon/IconSVG.tsx
@@ -36,7 +36,10 @@ const prop = (name: keyof IconSVGProps): string | undefined => {
 };
 
 /* eslint-disable max-len */
-const IconSVG: { [name: string]: React.FC } = {};
+export type IconSVGMap = {
+  [name: string]: React.FC;
+};
+const IconSVG: IconSVGMap = {};
 
 const BaseSVG = ({ children, viewBox }: React.SVGProps<SVGSVGElement>) => (
   <svg

--- a/packages/design-system/src/index.tsx
+++ b/packages/design-system/src/index.tsx
@@ -16,6 +16,7 @@
 // =============================================================================
 import { GlobalStyle } from "./styles/GlobalStyle";
 import { Button, ButtonKind, ButtonProps } from "./components/Button/Button";
+import Dropdown from "./components/Dropdown/Dropdown";
 import { Card, CardSection } from "./components/Card/Card";
 import { ErrorPage } from "./components/ErrorPage/ErrorPage";
 import { Header } from "./components/Header/Header";
@@ -43,6 +44,7 @@ export {
   Button,
   Card,
   CardSection,
+  Dropdown,
   ErrorPage,
   H1,
   H2,

--- a/packages/design-system/src/index.tsx
+++ b/packages/design-system/src/index.tsx
@@ -16,7 +16,7 @@
 // =============================================================================
 import { GlobalStyle } from "./styles/GlobalStyle";
 import { Button, ButtonKind, ButtonProps } from "./components/Button/Button";
-import Dropdown from "./components/Dropdown/Dropdown";
+import Dropdown from "./components/Dropdown";
 import { Card, CardSection } from "./components/Card/Card";
 import { ErrorPage } from "./components/ErrorPage/ErrorPage";
 import { Header } from "./components/Header/Header";


### PR DESCRIPTION
This implements an accessible dropdown menu for use in the Case Triage tool.

* `DropdownFocusManager` is a class that takes the `<Dropdown/>` element ref, and is able to move focus throughout the component.
* Element has support for up/down/tab/enter/escape key presses

https://user-images.githubusercontent.com/437360/116614685-18b38380-a8ef-11eb-8887-b907a57d77c3.mov

## Description of the change

> Description here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)


## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
