### PR TITLE
Add overlay styles and scroll lock to Modal

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recidiviz/design-system",
-  "version": "0.4.9",
+  "version": "0.5.0",
   "description": "UI components and styles for Recidiviz web products.",
   "author": "Recidiviz <team@recidiviz.org>",
   "license": "GPL-3.0-only",
@@ -22,6 +22,7 @@
   "dependencies": {
     "@fontsource/libre-baskerville": "^4.1.0",
     "@fontsource/libre-franklin": "^4.1.0",
+    "@types/body-scroll-lock": "^2.6.1",
     "body-scroll-lock": "^3.1.5",
     "polished": "^4.1.0",
     "prop-types": "^15.7.2",
@@ -46,7 +47,6 @@
     "@storybook/addons": "^6.1.15",
     "@storybook/node-logger": "^6.1.15",
     "@storybook/react": "^6.1.15",
-    "@types/body-scroll-lock": "^2.6.1",
     "@types/jest": "^26.0.18",
     "@types/node": "^14.14.11",
     "@types/prop-types": "^15.7.3",

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@fontsource/libre-baskerville": "^4.1.0",
     "@fontsource/libre-franklin": "^4.1.0",
+    "body-scroll-lock": "^3.1.5",
     "polished": "^4.1.0",
     "prop-types": "^15.7.2",
     "react-customizable-progressbar": "^1.0.2",
@@ -45,6 +46,7 @@
     "@storybook/addons": "^6.1.15",
     "@storybook/node-logger": "^6.1.15",
     "@storybook/react": "^6.1.15",
+    "@types/body-scroll-lock": "^2.6.1",
     "@types/jest": "^26.0.18",
     "@types/node": "^14.14.11",
     "@types/prop-types": "^15.7.3",

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@fontsource/libre-baskerville": "^4.1.0",
     "@fontsource/libre-franklin": "^4.1.0",
-    "@types/body-scroll-lock": "^2.6.1",
     "body-scroll-lock": "^3.1.5",
     "polished": "^4.1.0",
     "prop-types": "^15.7.2",
@@ -47,6 +46,7 @@
     "@storybook/addons": "^6.1.15",
     "@storybook/node-logger": "^6.1.15",
     "@storybook/react": "^6.1.15",
+    "@types/body-scroll-lock": "^2.6.1",
     "@types/jest": "^26.0.18",
     "@types/node": "^14.14.11",
     "@types/prop-types": "^15.7.3",

--- a/packages/design-system/src/components/Modal/Modal.stories.tsx
+++ b/packages/design-system/src/components/Modal/Modal.stories.tsx
@@ -47,6 +47,8 @@ export default {
   },
 } as Meta;
 
+// CSS texture from https://projects.verou.me/css3patterns/
+// helps make the overlay's blur effect more apparent
 const TexturedBackground = styled.div`
   background: linear-gradient(
       135deg,
@@ -74,7 +76,7 @@ const TexturedBackground = styled.div`
   background-color: #708090;
   background-size: 64px 128px;
   width: 100%;
-  height: 150vh;
+  height: calc(100vh - 20px);
 `;
 
 const Description = styled.span`

--- a/packages/design-system/src/components/Modal/Modal.stories.tsx
+++ b/packages/design-system/src/components/Modal/Modal.stories.tsx
@@ -41,34 +41,6 @@ export default {
       // Render modal inside an iframe so that `position: fixed`; is contained
       inlineStories: false,
       iframeHeight: "300px",
-      page: () => (
-        <>
-          <Title />
-          <Subtitle>
-            <>
-              <p>
-                The <strong>Modal</strong> component utilizes{" "}
-                <Link href="https://www.npmjs.com/package/react-modal">
-                  react-modal
-                </Link>
-                . for focus management and a basic modal implementation.
-              </p>
-              <p>
-                The modal is expected to be controlled by its enclosing
-                component. <br />
-                <strong>isOpen</strong> determines whether the modal is
-                shown/hidden <br />
-                <strong>onRequestClose</strong> is a hook that should update the{" "}
-                <strong>isOpen</strong> to false
-              </p>
-            </>
-          </Subtitle>
-          <StoryDescription />
-          <Primary />
-          <ArgsTable story={PRIMARY_STORY} />
-          <Stories />
-        </>
-      ),
     },
   },
 
@@ -85,17 +57,50 @@ export default {
   },
 } as Meta;
 
+const TexturedBackground = styled.div`
+  background: linear-gradient(
+      135deg,
+      #708090 21px,
+      #d9ecff 22px,
+      #d9ecff 24px,
+      transparent 24px,
+      transparent 67px,
+      #d9ecff 67px,
+      #d9ecff 69px,
+      transparent 69px
+    ),
+    linear-gradient(
+        225deg,
+        #708090 21px,
+        #d9ecff 22px,
+        #d9ecff 24px,
+        transparent 24px,
+        transparent 67px,
+        #d9ecff 67px,
+        #d9ecff 69px,
+        transparent 69px
+      )
+      0 64px;
+  background-color: #708090;
+  background-size: 64px 128px;
+  width: 100vw;
+  height: 150vh;
+`;
+
 const Description = styled.span`
   font-size: ${rem("17px")};
 `;
 
 const Template: Story<ModalProps> = ({ isOpen, onRequestClose }) => (
-  <ModalComponent isOpen={isOpen} onRequestClose={onRequestClose}>
-    <ModalHeading>Give Us Feedback</ModalHeading>
-    <Description>
-      After you click submit, we will move this item to the bottom of the list.
-    </Description>
-  </ModalComponent>
+  <TexturedBackground>
+    <ModalComponent isOpen={isOpen} onRequestClose={onRequestClose}>
+      <ModalHeading>Give Us Feedback</ModalHeading>
+      <Description>
+        After you click submit, we will move this item to the bottom of the
+        list.
+      </Description>
+    </ModalComponent>
+  </TexturedBackground>
 );
 
 export const Modal = Template.bind({});

--- a/packages/design-system/src/components/Modal/Modal.stories.tsx
+++ b/packages/design-system/src/components/Modal/Modal.stories.tsx
@@ -19,17 +19,7 @@ import { Story, Meta } from "@storybook/react";
 import ReactModal from "react-modal";
 import { rem } from "polished";
 import styled from "styled-components";
-import {
-  Title,
-  Subtitle,
-  Description as StoryDescription,
-  Primary,
-  ArgsTable,
-  Stories,
-  PRIMARY_STORY,
-} from "@storybook/addon-docs/blocks";
 import { Modal as ModalComponent, ModalHeading, ModalProps } from "./Modal";
-import { Link } from "../Typography/Link";
 
 ReactModal.setAppElement("#root");
 

--- a/packages/design-system/src/components/Modal/Modal.stories.tsx
+++ b/packages/design-system/src/components/Modal/Modal.stories.tsx
@@ -83,7 +83,7 @@ const TexturedBackground = styled.div`
       0 64px;
   background-color: #708090;
   background-size: 64px 128px;
-  width: 100vw;
+  width: 100%;
   height: 150vh;
 `;
 

--- a/packages/design-system/src/components/Modal/Modal.tsx
+++ b/packages/design-system/src/components/Modal/Modal.tsx
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
+
+import { disableBodyScroll, enableBodyScroll } from "body-scroll-lock";
 import { rgba } from "polished";
 import * as React from "react";
 import styled from "styled-components";
@@ -36,20 +38,47 @@ export const ModalHeading = styled(H3)`
 const UnstyledModal: React.FC<ModalProps> = ({
   children,
   className,
+  onAfterOpen,
+  onAfterClose,
   ...rest
-}) => (
-  <ReactModal {...rest} portalClassName={className} closeTimeoutMS={300}>
-    {children}
-  </ReactModal>
-);
+}) => {
+  const modalContentRef = React.useRef<HTMLDivElement | null>(null);
+
+  return (
+    <ReactModal
+      {...rest}
+      onAfterClose={() => {
+        if (modalContentRef.current) {
+          enableBodyScroll(modalContentRef.current);
+        }
+        if (onAfterClose) {
+          onAfterClose();
+        }
+      }}
+      onAfterOpen={(opts) => {
+        if (modalContentRef.current) {
+          disableBodyScroll(modalContentRef.current);
+        }
+        if (onAfterOpen) {
+          onAfterOpen(opts);
+        }
+      }}
+      portalClassName={className}
+      closeTimeoutMS={300}
+    >
+      {children}
+    </ReactModal>
+  );
+};
 
 const overlayColor = palette.marble5;
 
 /**
- * This is a styled wrapper around the
+ * This component is a wrapper around the
  * [React Modal]({https://www.npmjs.com/package/react-modal) package.
  * It expects to be controlled by its parent component.
- * It will dim and blur the page behind it while open.
+ * It will dim and blur the page behind it while open, and prevent the page from scrolling
+ * using the [Body Scroll Lock](https://www.npmjs.com/package/body-scroll-lock) package.
  *
  * The `isOpen` prop controls modal visibility, and the `onRequestClose`
  * prop is a hook that should set `isOpen` to `false`.

--- a/packages/design-system/src/components/Modal/Modal.tsx
+++ b/packages/design-system/src/components/Modal/Modal.tsx
@@ -71,8 +71,6 @@ const UnstyledModal: React.FC<ModalProps> = ({
   );
 };
 
-const overlayColor = palette.marble5;
-
 /**
  * This component is a wrapper around the
  * [React Modal]({https://www.npmjs.com/package/react-modal) package.
@@ -88,25 +86,24 @@ const overlayColor = palette.marble5;
  */
 export const Modal = styled(UnstyledModal)`
   .ReactModal__Overlay {
-    background-color: ${rgba(overlayColor, 0)};
+    /* not all browsers support backdrop-filter but it's a nice progressive enhancement */
+    backdrop-filter: blur(4px);
+    background-color: ${rgba(palette.marble5, 0.7)};
     height: 100%;
     left: 0;
+    opacity: 0;
     position: fixed;
     top: 0;
-    transition: background-color ${animation.defaultDurationMs}ms,
-      backdrop-filter ${animation.defaultDurationMs}ms;
+    transition: opacity ${animation.defaultDurationMs}ms;
     width: 100%;
     z-index: ${zindex.modal.backdrop};
 
     &.ReactModal__Overlay--after-open {
-      /* not all browsers support backdrop-filter but it's a nice progressive enhancement */
-      backdrop-filter: blur(4px);
-      background: ${rgba(overlayColor, 0.7)};
+      opacity: 1;
     }
 
     &.ReactModal__Overlay--before-close {
-      backdrop-filter: none;
-      background: ${rgba(overlayColor, 0)};
+      opacity: 0;
     }
   }
 

--- a/packages/design-system/src/components/Modal/Modal.tsx
+++ b/packages/design-system/src/components/Modal/Modal.tsx
@@ -42,6 +42,18 @@ const UnstyledModal = ({ children, className, ...rest }: ModalProps) => (
 );
 /* eslint-enable react/jsx-props-no-spreading */
 
+/**
+ * This is a styled wrapper around the
+ * [React Modal]({https://www.npmjs.com/package/react-modal) package.
+ * It expects to be controlled by its parent component.
+ * It will dim and blur the page behind it while open.
+ *
+ * The `isOpen` prop controls modal visibility, and the `onRequestClose`
+ * prop is a hook that should set `isOpen` to `false`.
+ *
+ * When using this component, you should make sure to [set the React Modal app element](
+ * https://reactcommunity.org/react-modal/accessibility/#the-app-element).
+ */
 export const Modal = styled(UnstyledModal)`
   .ReactModal__Overlay {
     position: fixed;

--- a/packages/design-system/src/components/Modal/Modal.tsx
+++ b/packages/design-system/src/components/Modal/Modal.tsx
@@ -14,18 +14,18 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
+import { rgba } from "polished";
 import * as React from "react";
 import styled from "styled-components";
 import ReactModal from "react-modal";
 import { H3 } from "../Typography/Headings";
-import { palette, zindex } from "../../styles";
+import { animation, palette, zindex } from "../../styles";
 
 // Reset default `react-modal` styles
 ReactModal.defaultStyles.content = {};
 ReactModal.defaultStyles.overlay = {};
 
 export interface ModalProps extends ReactModal.Props {
-  children: React.ReactChild | React.ReactChild[];
   className?: string;
 }
 
@@ -33,14 +33,17 @@ export const ModalHeading = styled(H3)`
   margin-top: 0;
 `;
 
-// Disable ESLint rule, as we are forwarding all props from the `react-modal` library
-/* eslint-disable react/jsx-props-no-spreading */
-const UnstyledModal = ({ children, className, ...rest }: ModalProps) => (
+const UnstyledModal: React.FC<ModalProps> = ({
+  children,
+  className,
+  ...rest
+}) => (
   <ReactModal {...rest} portalClassName={className} closeTimeoutMS={300}>
     {children}
   </ReactModal>
 );
-/* eslint-enable react/jsx-props-no-spreading */
+
+const overlayColor = palette.marble5;
 
 /**
  * This is a styled wrapper around the
@@ -56,12 +59,26 @@ const UnstyledModal = ({ children, className, ...rest }: ModalProps) => (
  */
 export const Modal = styled(UnstyledModal)`
   .ReactModal__Overlay {
+    background-color: ${rgba(overlayColor, 0)};
+    height: 100%;
+    left: 0;
     position: fixed;
     top: 0;
-    left: 0;
+    transition: background-color ${animation.defaultDurationMs}ms,
+      backdrop-filter ${animation.defaultDurationMs}ms;
     width: 100%;
-    height: 100%;
     z-index: ${zindex.modal.backdrop};
+
+    &.ReactModal__Overlay--after-open {
+      /* not all browsers support backdrop-filter but it's a nice progressive enhancement */
+      backdrop-filter: blur(4px);
+      background: ${rgba(overlayColor, 0.7)};
+    }
+
+    &.ReactModal__Overlay--before-close {
+      backdrop-filter: none;
+      background: ${rgba(overlayColor, 0)};
+    }
   }
 
   .ReactModal__Content {

--- a/packages/design-system/src/components/Modal/Modal.tsx
+++ b/packages/design-system/src/components/Modal/Modal.tsx
@@ -111,19 +111,22 @@ export const Modal = styled(UnstyledModal)`
   }
 
   .ReactModal__Content {
-    transform: translate(-50%, -50%) scale(0.75);
-    transition: transform 300ms ease-in-out;
-    position: fixed;
-    width: 462px;
-    left: 50%;
-    top: 50%;
-    z-index: ${zindex.modal.content};
-    padding: 40px;
     background: ${palette.white};
+    border-radius: 8px;
     box-shadow: 0px 15px 40px rgba(22, 26, 33, 0.3),
       inset 0px -1px 1px rgba(19, 44, 82, 0.2);
-    border-radius: 8px;
+    left: 50%;
+    max-height: 90vh;
+    max-width: 90vw;
     outline: none;
+    overflow: auto;
+    padding: 40px;
+    position: fixed;
+    top: 50%;
+    transform: translate(-50%, -50%) scale(0.75);
+    transition: transform 300ms ease-in-out;
+    width: 462px;
+    z-index: ${zindex.modal.content};
   }
   .ReactModal__Overlay[class*="--after-open"] .ReactModal__Content {
     transform: translate(-50%, -50%) scale(1);

--- a/packages/design-system/src/styles/index.ts
+++ b/packages/design-system/src/styles/index.ts
@@ -110,7 +110,11 @@ export const spacing = {
 
 export const zindex = {
   modal: {
-    backdrop: 1,
-    content: 2,
+    backdrop: 1000,
+    content: 1001,
   },
+};
+
+export const animation = {
+  defaultDurationMs: 500,
 };

--- a/packages/design-system/yarn.lock
+++ b/packages/design-system/yarn.lock
@@ -2067,6 +2067,11 @@
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
   integrity sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
 
+"@types/body-scroll-lock@^2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@types/body-scroll-lock/-/body-scroll-lock-2.6.1.tgz#0dbd2b6ad2f4cfcece7102d6cf8630ce95508ee0"
+  integrity sha512-PPFm/2A6LfKmSpvMg58gHtSqwwMChbcKKGhSCRIhY4MyFzhY8moAN6HrTCpOeZQUqkFdTFfMqr7njeqGLKt72Q==
+
 "@types/braces@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/braces/-/braces-3.0.0.tgz#7da1c0d44ff1c7eb660a36ec078ea61ba7eb42cb"
@@ -3273,6 +3278,11 @@ body-parser@1.19.0:
     qs "6.7.0"
     raw-body "2.4.0"
     type-is "~1.6.17"
+
+body-scroll-lock@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/body-scroll-lock/-/body-scroll-lock-3.1.5.tgz#c1392d9217ed2c3e237fee1e910f6cdd80b7aaec"
+  integrity sha512-Yi1Xaml0EvNA0OYWxXiYNqY24AfWkbA6w5vxE7GWxtKfzIbZM+Qw+aSmkgsbWzbHiy/RCSkUZBplVxTA+E4jJg==
 
 boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Description of the change

In Spotlight I extended the `Modal` component with some features that I expect would be universally applicable: 

1. A translucent color and blur effect on the overlay when it's open
2. Preventing the page behind the modal from scrolling while it's open
3. Some styles to make the size of the modal more responsive to small screens and scroll overflowing content

This brings all three of those features into the Design System, and bumps the package version accordingly.

(The scroll locking behavior, unfortunately, does not work in Storybook because it doesn't seem to work in an `iframe`; however, I verified the behavior by installing the package locally in another application).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

n/a

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
