### PR TITLE
Fix scroll lock behavior when modal is open

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recidiviz/design-system",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "UI components and styles for Recidiviz web products.",
   "author": "Recidiviz <team@recidiviz.org>",
   "license": "GPL-3.0-only",

--- a/packages/design-system/src/components/Modal/Modal.stories.tsx
+++ b/packages/design-system/src/components/Modal/Modal.stories.tsx
@@ -76,7 +76,7 @@ const TexturedBackground = styled.div`
   background-color: #708090;
   background-size: 64px 128px;
   width: 100%;
-  height: calc(100vh - 20px);
+  height: calc(120vh);
 `;
 
 const Description = styled.span`
@@ -86,10 +86,10 @@ const Description = styled.span`
 const Template: Story<ModalProps> = ({ isOpen, onRequestClose }) => (
   <TexturedBackground>
     <ModalComponent isOpen={isOpen} onRequestClose={onRequestClose}>
-      <ModalHeading>Give Us Feedback</ModalHeading>
+      <ModalHeading>This is a modal.</ModalHeading>
       <Description>
-        After you click submit, we will move this item to the bottom of the
-        list.
+        The background should not scroll while this modal is open; when the
+        modal is closed, it should scroll freely up and down.
       </Description>
     </ModalComponent>
   </TexturedBackground>

--- a/packages/design-system/src/components/Modal/Modal.tsx
+++ b/packages/design-system/src/components/Modal/Modal.tsx
@@ -27,7 +27,7 @@ import { animation, palette, zindex } from "../../styles";
 ReactModal.defaultStyles.content = {};
 ReactModal.defaultStyles.overlay = {};
 
-export interface ModalProps extends ReactModal.Props {
+export interface ModalProps extends Omit<ReactModal.Props, "contentRef"> {
   className?: string;
 }
 
@@ -46,7 +46,11 @@ const UnstyledModal: React.FC<ModalProps> = ({
 
   return (
     <ReactModal
+      closeTimeoutMS={300}
       {...rest}
+      contentRef={(node) => {
+        if (node) modalContentRef.current = node;
+      }}
       onAfterClose={() => {
         if (modalContentRef.current) {
           enableBodyScroll(modalContentRef.current);
@@ -64,7 +68,6 @@ const UnstyledModal: React.FC<ModalProps> = ({
         }
       }}
       portalClassName={className}
-      closeTimeoutMS={300}
     >
       {children}
     </ReactModal>


### PR DESCRIPTION
## Description of the change

A flaw in my testing when I implemented this feature obscured what was, in retrospect, a pretty glaring bug that prevented the scroll lock feature from working; we were never actually setting the ref on the component that would enable the locking behavior. (It is conditional behind what I thought was just an annoying type safety check, but was actually introducing this problem 😐)

Anyway this fixes that and you can now see the scroll locking behavior in Storybook. Verified the bundle locally against Spotlight (where previously I had failed to remove the redundant scroll-locking behavior implemented there, which is why I didn't see the bug there).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

n/a

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
