### PR TITLE
Add default font sizes

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recidiviz/design-system",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "UI components and styles for Recidiviz web products.",
   "author": "Recidiviz <team@recidiviz.org>",
   "license": "GPL-3.0-only",

--- a/packages/design-system/src/components/Dropdown/Dropdown.styles.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.styles.tsx
@@ -35,6 +35,7 @@ export const MenuItemElement = styled.button.attrs({
   width: 100%;
   text-align: left;
   white-space: nowrap;
+  font-size: ${rem(14)};
 
   &:focus {
     outline: none;
@@ -133,7 +134,7 @@ interface ToggleElementProps {
 export const ToggleElement = styled.button.attrs({
   type: "button",
 })<ToggleElementProps>`
-  padding: ${rem(spacing.sm)};
+  padding: ${rem(spacing.xs)} ${rem(spacing.sm)};
   position: relative;
   background: white;
   cursor: pointer;
@@ -146,6 +147,7 @@ export const ToggleElement = styled.button.attrs({
   border: 1px solid ${palette.slate30};
   box-sizing: border-box;
   border-radius: 4px;
+  font-size: ${rem(14)};
 
   &:hover {
     border-color: ${palette.signal.links};

--- a/packages/design-system/src/components/Need/Need.tsx
+++ b/packages/design-system/src/components/Need/Need.tsx
@@ -18,11 +18,7 @@ import * as React from "react";
 import { NeedsContainer } from "./Need.styles";
 import { Icon } from "../Icon/Icon";
 import { IconSVG } from "../Icon/IconSVG";
-
-export enum NeedState {
-  NOT_MET = "NOT_MET",
-  MET = "MET",
-}
+import { NeedState } from "./Need.types";
 
 export interface NeedProps {
   className?: string;

--- a/packages/design-system/src/components/Need/Need.types.tsx
+++ b/packages/design-system/src/components/Need/Need.types.tsx
@@ -14,24 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
-import styled from "styled-components";
-import { rem, rgba } from "polished";
-import { palette } from "../../styles";
-import { NeedState } from "./Need.types";
-
-interface NeedsContainerProps {
-  state: NeedState;
+export enum NeedState {
+  NOT_MET = "NOT_MET",
+  MET = "MET",
 }
-
-export const NeedsContainer = styled.div<NeedsContainerProps>`
-  width: ${rem("24px")};
-  height: ${rem("24px")};
-  vertical-align: middle;
-
-  & path {
-    fill: ${(props) =>
-      props.state === NeedState.MET
-        ? palette.signal.links
-        : rgba(palette.slate, 0.4)};
-  }
-`;

--- a/packages/design-system/src/index.tsx
+++ b/packages/design-system/src/index.tsx
@@ -22,7 +22,7 @@ import { ErrorPage } from "./components/ErrorPage/ErrorPage";
 import { Header } from "./components/Header/Header";
 import { Icon } from "./components/Icon/Icon";
 import { IconSVG } from "./components/Icon/IconSVG";
-import { Need, NeedState } from "./components/Need/Need";
+import { Need } from "./components/Need/Need";
 import { Search } from "./components/Search/Search";
 import { fonts, palette, spacing, zindex } from "./styles";
 
@@ -38,6 +38,7 @@ import {
 import Assets from "./assets";
 import { Modal, ModalHeading, ModalProps } from "./components/Modal/Modal";
 import { Link } from "./components/Typography/Link";
+import { NeedState } from "./components/Need/Need.types";
 
 export {
   Assets,


### PR DESCRIPTION
## Description of the change

This PR sets the default font-size for some of the dropdown elements. It also cleans up a circular dependency in imports for Need/NeedState.

Previously on Safari the dropdowns looked like this in Case Triage:
<img width="558" alt="image" src="https://user-images.githubusercontent.com/993682/118909044-1de86a80-b8be-11eb-8b9e-2a519b49c78c.png">


Now they look like this:
<img width="546" alt="image" src="https://user-images.githubusercontent.com/993682/118908905-eda0cc00-b8bd-11eb-823f-1832edf82b82.png">


## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)

## Related issues

N/A

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [X] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
