### PR TITLE
Allow `Button`s to accept generic html attributes

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recidiviz/design-system",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "UI components and styles for Recidiviz web products.",
   "author": "Recidiviz <team@recidiviz.org>",
   "license": "GPL-3.0-only",

--- a/packages/design-system/src/components/Button/Button.tsx
+++ b/packages/design-system/src/components/Button/Button.tsx
@@ -30,6 +30,7 @@ export const Button = ({
   kind = "primary",
   disabled = false,
   onClick,
+  ...attributes
 }: ButtonProps): JSX.Element => {
   const Component = KindMap[kind];
 
@@ -38,6 +39,7 @@ export const Button = ({
       className={className}
       onClick={disabled ? undefined : onClick}
       disabled={disabled}
+      {...attributes}
     >
       {children}
     </Component>

--- a/packages/design-system/src/components/Button/Button.types.ts
+++ b/packages/design-system/src/components/Button/Button.types.ts
@@ -14,11 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
-import { MouseEventHandler, ReactChild } from "react";
+import React, { MouseEventHandler, ReactChild } from "react";
 
 export type ButtonKind = "primary" | "secondary" | "link";
 
-export interface ButtonProps {
+export interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
   children: ReactChild | ReactChild[];
 
   className?: string;


### PR DESCRIPTION
## Description of the change

Previously we couldn't add html attributes like `aria-label` to our buttons. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
