### PR TITLE
Integrate Dropdown and Button styles

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recidiviz/design-system",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "UI components and styles for Recidiviz web products.",
   "author": "Recidiviz <team@recidiviz.org>",
   "license": "GPL-3.0-only",

--- a/packages/design-system/src/components/Button/Button.stories.tsx
+++ b/packages/design-system/src/components/Button/Button.stories.tsx
@@ -18,6 +18,7 @@ import * as React from "react";
 import { Story, Meta } from "@storybook/react";
 import { ButtonProps } from "./Button.types";
 import { Button } from "./Button";
+import { IconSVG } from "../Icon/IconSVG";
 
 export default {
   title: "Design System/Atoms/Button",
@@ -35,6 +36,12 @@ export default {
         type: "select",
       },
     },
+    icon: {
+      control: {
+        options: Object.keys(IconSVG),
+        type: "select",
+      },
+    },
   },
 } as Meta;
 
@@ -44,8 +51,17 @@ const Template: Story<ButtonProps> = ({
   disabled,
   onClick,
   shape,
+  icon,
+  iconSize,
 }) => (
-  <Button kind={kind} onClick={onClick} disabled={disabled} shape={shape}>
+  <Button
+    kind={kind}
+    onClick={onClick}
+    disabled={disabled}
+    shape={shape}
+    icon={icon}
+    iconSize={iconSize}
+  >
     {children}
   </Button>
 );
@@ -66,6 +82,13 @@ export const BorderlessButton: Story<ButtonProps> = Template.bind({});
 BorderlessButton.args = {
   children: "See Details",
   kind: "borderless",
+  shape: "block",
+};
+
+export const IconButton: Story<ButtonProps> = Template.bind({});
+IconButton.args = {
+  icon: "Place",
+  kind: "secondary",
   shape: "block",
 };
 

--- a/packages/design-system/src/components/Button/Button.stories.tsx
+++ b/packages/design-system/src/components/Button/Button.stories.tsx
@@ -25,8 +25,14 @@ export default {
   argTypes: {
     kind: {
       control: {
-        type: "radio",
+        type: "select",
         options: ["primary", "secondary", "link"],
+      },
+    },
+    shape: {
+      control: {
+        options: ["pill", "block"],
+        type: "select",
       },
     },
   },
@@ -37,20 +43,28 @@ const Template: Story<ButtonProps> = ({
   kind,
   disabled,
   onClick,
+  shape,
 }) => (
-  <Button kind={kind} onClick={onClick} disabled={disabled}>
+  <Button kind={kind} onClick={onClick} disabled={disabled} shape={shape}>
     {children}
   </Button>
 );
 
-export const PrimaryButton = Template.bind({});
+export const PrimaryButton: Story<ButtonProps> = Template.bind({});
 PrimaryButton.args = {
   children: "Add to Calendar",
   kind: "primary",
 };
 
-export const SecondaryButton = Template.bind({});
+export const SecondaryButton: Story<ButtonProps> = Template.bind({});
 SecondaryButton.args = { children: "See Details", kind: "secondary" };
 
-export const LinkButton = Template.bind({});
+export const LinkButton: Story<ButtonProps> = Template.bind({});
 LinkButton.args = { children: "See Details", kind: "link" };
+
+export const BlockButton: Story<ButtonProps> = Template.bind({});
+BlockButton.args = {
+  children: "Suggested action",
+  shape: "block",
+  kind: "secondary",
+};

--- a/packages/design-system/src/components/Button/Button.stories.tsx
+++ b/packages/design-system/src/components/Button/Button.stories.tsx
@@ -26,7 +26,7 @@ export default {
     kind: {
       control: {
         type: "select",
-        options: ["primary", "secondary", "link"],
+        options: ["primary", "secondary", "link", "borderless"],
       },
     },
     shape: {
@@ -61,6 +61,13 @@ SecondaryButton.args = { children: "See Details", kind: "secondary" };
 
 export const LinkButton: Story<ButtonProps> = Template.bind({});
 LinkButton.args = { children: "See Details", kind: "link" };
+
+export const BorderlessButton: Story<ButtonProps> = Template.bind({});
+BorderlessButton.args = {
+  children: "See Details",
+  kind: "borderless",
+  shape: "block",
+};
 
 export const BlockButton: Story<ButtonProps> = Template.bind({});
 BlockButton.args = {

--- a/packages/design-system/src/components/Button/Button.styles.tsx
+++ b/packages/design-system/src/components/Button/Button.styles.tsx
@@ -29,8 +29,7 @@ const pillStyles = css`
 const blockStyles = css`
   border-radius: ${rem(4)};
 
-  height: ${rem(32)};
-  min-height: initial;
+  min-height: ${rem(32)};
   min-width: ${rem(32)};
   padding: ${rem(spacing.xs)} ${rem(spacing.sm)};
 `;

--- a/packages/design-system/src/components/Button/Button.styles.tsx
+++ b/packages/design-system/src/components/Button/Button.styles.tsx
@@ -35,7 +35,63 @@ const blockStyles = css`
   padding: ${rem(spacing.xs)} ${rem(spacing.sm)};
 `;
 
-const BaseButton = styled.button.attrs({
+const primaryStyles = css`
+  border: none;
+  background-color: ${palette.signal.links};
+  color: ${palette.white};
+
+  &:hover,
+  &:focus {
+    background-color: ${palette.pine4};
+  }
+
+  &:active,
+  &[aria-expanded="true"] {
+    background-color: ${palette.pine3};
+  }
+
+  &:disabled {
+    background-color: ${palette.slate10};
+    color: ${palette.slate80};
+  }
+`;
+
+const secondaryStyles = css`
+  background-color: transparent;
+  border: 1px solid ${palette.slate30};
+  color: ${palette.text.normal};
+
+  &:hover,
+  &:focus {
+    background-color: ${palette.slate20};
+    color: ${palette.pine4};
+  }
+
+  &:active,
+  &[aria-expanded="true"] {
+    border-color: ${palette.pine4};
+    color: ${palette.signal.links};
+  }
+
+  &:disabled {
+    background-color: transparent;
+    border-color: ${palette.slate20};
+    color: ${palette.slate60};
+  }
+`;
+
+const borderlessStyles = css`
+  ${secondaryStyles}
+
+  border-color: transparent !important;
+
+  &:hover,
+  &:focus {
+    background-color: transparent;
+  }
+`;
+
+export const BaseButton = styled.button.attrs({
   type: "button",
 })<Pick<ButtonProps, "kind" | "shape">>`
   align-items: center;
@@ -61,49 +117,19 @@ const BaseButton = styled.button.attrs({
         return "";
     }
   }}
-`;
 
-export const PrimaryButton = styled(BaseButton)<ButtonProps>`
-  border: none;
-  background-color: ${palette.signal.links};
-  color: ${palette.white};
-
-  &:hover,
-  &:focus {
-    background-color: ${palette.pine4};
-  }
-
-  &:active {
-    background-color: ${palette.pine3};
-  }
-
-  &:disabled {
-    background-color: ${palette.slate10};
-    color: ${palette.slate80};
-  }
-`;
-
-export const SecondaryButton = styled(BaseButton)<ButtonProps>`
-  background-color: transparent;
-  border: 1px solid ${palette.slate30};
-  color: ${palette.text.normal};
-
-  &:hover,
-  &:focus {
-    background-color: ${palette.slate20};
-    color: ${palette.pine4};
-  }
-
-  &:active {
-    border-color: ${palette.pine4};
-    color: ${palette.signal.links};
-  }
-
-  &:disabled {
-    background-color: transparent;
-    border-color: ${palette.slate20};
-    color: ${palette.slate60};
-  }
+  ${(props) => {
+    switch (props.kind) {
+      case "primary":
+        return primaryStyles;
+      case "secondary":
+        return secondaryStyles;
+      case "borderless":
+        return borderlessStyles;
+      default:
+        return "";
+    }
+  }}
 `;
 
 export const LinkButton = styled.button.attrs({
@@ -118,11 +144,13 @@ export const LinkButton = styled.button.attrs({
 
   &:active,
   &:hover,
-  &:focus {
+  &:focus,
+  &[aria-expanded="true"] {
     text-decoration: underline;
   }
 
-  &:active {
+  &:active,
+  &[aria-expanded="true"] {
     color: ${palette.pine4};
   }
 

--- a/packages/design-system/src/components/Button/Button.styles.tsx
+++ b/packages/design-system/src/components/Button/Button.styles.tsx
@@ -14,26 +14,53 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
-import styled from "styled-components";
+import { rem } from "polished";
+import styled, { css } from "styled-components";
 import { ButtonProps } from "./Button.types";
-import { fonts, palette } from "../../styles";
+import { animation, fonts, palette, spacing } from "../../styles";
+
+const pillStyles = css`
+  min-width: ${rem(129)};
+  min-height: ${rem(40)};
+  padding: ${rem(12)} ${rem(16)};
+  border-radius: ${rem(999)};
+`;
+
+const blockStyles = css`
+  border-radius: ${rem(4)};
+
+  height: ${rem(32)};
+  min-height: initial;
+  min-width: ${rem(32)};
+  padding: ${rem(spacing.xs)} ${rem(spacing.sm)};
+`;
 
 const BaseButton = styled.button.attrs({
   type: "button",
-})`
-  cursor: pointer;
-  min-width: 129px;
-  min-height: 40px;
-  padding: 12px 16px;
-  border-radius: 999px;
-  display: flex;
+})<Pick<ButtonProps, "kind" | "shape">>`
   align-items: center;
+  cursor: pointer;
+  display: flex;
   font-family: ${fonts.body};
+  font-size: ${rem(14)};
   justify-content: center;
+  transition-duration: ${animation.defaultDurationMs}ms;
+  transition-property: color, background-color, border-color;
 
   &:disabled {
     cursor: not-allowed;
   }
+
+  ${(props) => {
+    switch (props.shape) {
+      case "pill":
+        return pillStyles;
+      case "block":
+        return blockStyles;
+      default:
+        return "";
+    }
+  }}
 `;
 
 export const PrimaryButton = styled(BaseButton)<ButtonProps>`
@@ -58,11 +85,12 @@ export const PrimaryButton = styled(BaseButton)<ButtonProps>`
 
 export const SecondaryButton = styled(BaseButton)<ButtonProps>`
   background-color: transparent;
-  border: 1px solid ${palette.signal.links};
-  color: ${palette.signal.links};
+  border: 1px solid ${palette.slate30};
+  color: ${palette.text.normal};
 
   &:hover,
   &:focus {
+    background-color: ${palette.slate20};
     color: ${palette.pine4};
   }
 
@@ -72,8 +100,9 @@ export const SecondaryButton = styled(BaseButton)<ButtonProps>`
   }
 
   &:disabled {
-    background-color: ${palette.slate20};
-    color: ${palette.slate70};
+    background-color: transparent;
+    border-color: ${palette.slate20};
+    color: ${palette.slate60};
   }
 `;
 

--- a/packages/design-system/src/components/Button/Button.tsx
+++ b/packages/design-system/src/components/Button/Button.tsx
@@ -28,6 +28,7 @@ export const Button = ({
   children,
   className = "",
   kind = "primary",
+  shape = "pill",
   disabled = false,
   onClick,
   ...attributes
@@ -39,6 +40,7 @@ export const Button = ({
       className={className}
       onClick={disabled ? undefined : onClick}
       disabled={disabled}
+      shape={shape}
       {...attributes}
     >
       {children}

--- a/packages/design-system/src/components/Button/Button.tsx
+++ b/packages/design-system/src/components/Button/Button.tsx
@@ -16,13 +16,7 @@
 // =============================================================================
 import * as React from "react";
 import { ButtonProps } from "./Button.types";
-import { LinkButton, PrimaryButton, SecondaryButton } from "./Button.styles";
-
-const KindMap = {
-  primary: PrimaryButton,
-  secondary: SecondaryButton,
-  link: LinkButton,
-};
+import { LinkButton, BaseButton } from "./Button.styles";
 
 export const Button = ({
   children,
@@ -33,7 +27,7 @@ export const Button = ({
   onClick,
   ...attributes
 }: ButtonProps): JSX.Element => {
-  const Component = KindMap[kind];
+  const Component = kind === "link" ? LinkButton : BaseButton;
 
   return (
     <Component
@@ -41,6 +35,7 @@ export const Button = ({
       onClick={disabled ? undefined : onClick}
       disabled={disabled}
       shape={shape}
+      kind={kind}
       {...attributes}
     >
       {children}

--- a/packages/design-system/src/components/Button/Button.tsx
+++ b/packages/design-system/src/components/Button/Button.tsx
@@ -17,6 +17,7 @@
 import * as React from "react";
 import { ButtonProps } from "./Button.types";
 import { LinkButton, BaseButton } from "./Button.styles";
+import { Icon } from "../Icon/Icon";
 
 export const Button = ({
   children,
@@ -25,6 +26,8 @@ export const Button = ({
   shape = "pill",
   disabled = false,
   onClick,
+  icon,
+  iconSize = 16,
   ...attributes
 }: ButtonProps): JSX.Element => {
   const Component = kind === "link" ? LinkButton : BaseButton;
@@ -38,7 +41,11 @@ export const Button = ({
       kind={kind}
       {...attributes}
     >
-      {children}
+      {icon ? (
+        <Icon kind={icon} fill="currentColor" size={iconSize} />
+      ) : (
+        children
+      )}
     </Component>
   );
 };

--- a/packages/design-system/src/components/Button/Button.types.ts
+++ b/packages/design-system/src/components/Button/Button.types.ts
@@ -15,12 +15,16 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 import React, { MouseEventHandler, ReactNode } from "react";
+import { IconSVG } from "../Icon/IconSVG";
 
 export type ButtonKind = "primary" | "secondary" | "link" | "borderless";
 export type ButtonShape = "pill" | "block";
 
 export interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
-  children: ReactNode;
+  /**
+   * children will not be rendered if an icon is specified
+   */
+  children?: ReactNode;
 
   className?: string;
 
@@ -32,4 +36,6 @@ export interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
   disabled?: boolean;
 
   onClick?: MouseEventHandler<HTMLButtonElement>;
+  icon?: keyof typeof IconSVG;
+  iconSize?: number;
 }

--- a/packages/design-system/src/components/Button/Button.types.ts
+++ b/packages/design-system/src/components/Button/Button.types.ts
@@ -14,13 +14,13 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
-import React, { MouseEventHandler, ReactChild } from "react";
+import React, { MouseEventHandler, ReactNode } from "react";
 
 export type ButtonKind = "primary" | "secondary" | "link";
 export type ButtonShape = "pill" | "block";
 
 export interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
-  children: ReactChild | ReactChild[];
+  children: ReactNode;
 
   className?: string;
 

--- a/packages/design-system/src/components/Button/Button.types.ts
+++ b/packages/design-system/src/components/Button/Button.types.ts
@@ -16,7 +16,7 @@
 // =============================================================================
 import React, { MouseEventHandler, ReactNode } from "react";
 
-export type ButtonKind = "primary" | "secondary" | "link";
+export type ButtonKind = "primary" | "secondary" | "link" | "borderless";
 export type ButtonShape = "pill" | "block";
 
 export interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {

--- a/packages/design-system/src/components/Button/Button.types.ts
+++ b/packages/design-system/src/components/Button/Button.types.ts
@@ -17,6 +17,7 @@
 import React, { MouseEventHandler, ReactChild } from "react";
 
 export type ButtonKind = "primary" | "secondary" | "link";
+export type ButtonShape = "pill" | "block";
 
 export interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
   children: ReactChild | ReactChild[];
@@ -24,6 +25,10 @@ export interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
   className?: string;
 
   kind?: ButtonKind;
+  /**
+   * `shape` has no effect when `kind === "link"`
+   */
+  shape?: ButtonShape;
   disabled?: boolean;
 
   onClick?: MouseEventHandler<HTMLButtonElement>;

--- a/packages/design-system/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.stories.tsx
@@ -46,22 +46,19 @@ export default {
       type: "string",
       defaultValue: "Create a reminder",
     },
-    borderless: {
-      name: "Dropdown.Toggle borderless",
-      type: "boolean",
-      defaultValue: false,
-    },
     kind: {
       name: "Dropdown.Toggle kind",
       type: "string",
-      options: ["primary", "secondary", "link"],
+      options: ["secondary", "link", "primary", "borderless"],
       control: { type: "select" },
+      defaultValue: "secondary",
     },
     shape: {
       name: "Dropdown.Toggle shape",
       type: "string",
       options: ["block", "pill"],
       control: { type: "select" },
+      defaultValue: "block",
     },
   },
 } as Meta;
@@ -71,7 +68,6 @@ type CombinedArgs = ToggleProps & MenuProps;
 const Template: Story<CombinedArgs> = ({
   alignment,
   ariaLabel,
-  borderless,
   kind,
   shape,
 }) => {
@@ -83,12 +79,7 @@ const Template: Story<CombinedArgs> = ({
         other focusable element
       </button>
       <Dropdown>
-        <Dropdown.Toggle
-          ariaLabel={ariaLabel}
-          borderless={borderless}
-          kind={kind}
-          shape={shape}
-        >
+        <Dropdown.Toggle ariaLabel={ariaLabel} kind={kind} shape={shape}>
           <Dropdown.ToggleIcon kind={IconSVG.Clock} size={16} />
         </Dropdown.Toggle>
         <Dropdown.Menu alignment={alignment}>

--- a/packages/design-system/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.stories.tsx
@@ -19,6 +19,8 @@ import { Story, Meta } from "@storybook/react";
 import Dropdown from "./Dropdown";
 import { ToastProvider, useToasts } from "../Toast/Toast";
 import { IconSVG } from "../Icon/IconSVG";
+import { ToggleProps } from "./DropdownToggle";
+import { MenuProps } from "./DropdownMenu";
 
 export default {
   title: "Design System/Atoms/ButtonDropdown",
@@ -30,9 +32,49 @@ export default {
       </ToastProvider>
     ),
   ],
+  argTypes: {
+    alignment: {
+      name: "Dropdown.Menu alignment",
+      type: "string",
+      options: ["left", "right"],
+      control: {
+        type: "select",
+      },
+    },
+    ariaLabel: {
+      name: "Dropdown.Toggle ariaLabel",
+      type: "string",
+      defaultValue: "Create a reminder",
+    },
+    borderless: {
+      name: "Dropdown.Toggle borderless",
+      type: "boolean",
+      defaultValue: false,
+    },
+    kind: {
+      name: "Dropdown.Toggle kind",
+      type: "string",
+      options: ["primary", "secondary", "link"],
+      control: { type: "select" },
+    },
+    shape: {
+      name: "Dropdown.Toggle shape",
+      type: "string",
+      options: ["block", "pill"],
+      control: { type: "select" },
+    },
+  },
 } as Meta;
 
-const Template: Story = ({ children, kind, disabled, onClick }) => {
+type CombinedArgs = ToggleProps & MenuProps;
+
+const Template: Story<CombinedArgs> = ({
+  alignment,
+  ariaLabel,
+  borderless,
+  kind,
+  shape,
+}) => {
   const { addToast } = useToasts();
 
   return (
@@ -41,10 +83,15 @@ const Template: Story = ({ children, kind, disabled, onClick }) => {
         other focusable element
       </button>
       <Dropdown>
-        <Dropdown.Toggle ariaLabel="Create a reminder">
+        <Dropdown.Toggle
+          ariaLabel={ariaLabel}
+          borderless={borderless}
+          kind={kind}
+          shape={shape}
+        >
           <Dropdown.ToggleIcon kind={IconSVG.Clock} size={16} />
         </Dropdown.Toggle>
-        <Dropdown.Menu>
+        <Dropdown.Menu alignment={alignment}>
           <Dropdown.MenuLabel>Remind Me In</Dropdown.MenuLabel>
           <Dropdown.MenuItem
             label="7 days"
@@ -65,3 +112,4 @@ const Template: Story = ({ children, kind, disabled, onClick }) => {
 };
 
 export const DropdownStory = Template.bind({});
+DropdownStory.storyName = "ButtonDropdown";

--- a/packages/design-system/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.stories.tsx
@@ -44,7 +44,6 @@ export default {
     ariaLabel: {
       name: "Dropdown.Toggle ariaLabel",
       type: "string",
-      defaultValue: "Create a reminder",
     },
     kind: {
       name: "Dropdown.Toggle kind",
@@ -60,6 +59,12 @@ export default {
       control: { type: "select" },
       defaultValue: "block",
     },
+    icon: {
+      name: "Dropdown.Toggle icon",
+      type: "string",
+      options: Object.keys(IconSVG),
+      control: { type: "select" },
+    },
   },
 } as Meta;
 
@@ -68,8 +73,10 @@ type CombinedArgs = ToggleProps & MenuProps;
 const Template: Story<CombinedArgs> = ({
   alignment,
   ariaLabel,
+  children,
   kind,
   shape,
+  icon,
 }) => {
   const { addToast } = useToasts();
 
@@ -79,8 +86,13 @@ const Template: Story<CombinedArgs> = ({
         other focusable element
       </button>
       <Dropdown>
-        <Dropdown.Toggle ariaLabel={ariaLabel} kind={kind} shape={shape}>
-          <Dropdown.ToggleIcon kind={IconSVG.Clock} size={16} />
+        <Dropdown.Toggle
+          ariaLabel={ariaLabel}
+          kind={kind}
+          shape={shape}
+          icon={icon}
+        >
+          {children}
         </Dropdown.Toggle>
         <Dropdown.Menu alignment={alignment}>
           <Dropdown.MenuLabel>Remind Me In</Dropdown.MenuLabel>
@@ -102,5 +114,11 @@ const Template: Story<CombinedArgs> = ({
   );
 };
 
-export const DropdownStory = Template.bind({});
-DropdownStory.storyName = "ButtonDropdown";
+export const ButtonDropdown: Story<CombinedArgs> = Template.bind({});
+ButtonDropdown.args = { children: "Create a reminder" };
+
+export const IconButtonDropdown: Story<CombinedArgs> = Template.bind({});
+IconButtonDropdown.args = {
+  ariaLabel: "Create a reminder",
+  icon: "Clock",
+};

--- a/packages/design-system/src/components/Dropdown/Dropdown.styles.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.styles.tsx
@@ -17,6 +17,7 @@
 import { rem } from "polished";
 import styled, { css } from "styled-components";
 import { fonts, palette, spacing } from "../../styles";
+import { Button } from "../Button/Button";
 
 export const MenuItemElement = styled.button.attrs({
   type: "button",
@@ -27,10 +28,10 @@ export const MenuItemElement = styled.button.attrs({
   height: ${rem(32)};
   line-height: ${rem(32)};
   padding: 0 ${rem(spacing.md)};
-  transition: color, background-color;
-  transition-easing: ease-in-out;
+  transition-property: color, background-color;
+  transition-timing-function: ease-in-out;
   transition-duration: 0.1s;
-  background-color: white;
+  background-color: ${palette.white};
   border: none;
   width: 100%;
   text-align: left;
@@ -131,43 +132,21 @@ interface ToggleElementProps {
   shown: boolean;
 }
 
-export const ToggleElement = styled.button.attrs({
-  type: "button",
-})<ToggleElementProps>`
-  padding: ${rem(spacing.xs)} ${rem(spacing.sm)};
-  position: relative;
-  background: white;
-  cursor: pointer;
-  color: ${palette.pine4};
-  min-height: initial;
-  min-width: ${rem(32)};
-  height: ${rem(32)};
-  margin: 0;
-
-  border: 1px solid ${palette.slate30};
-  box-sizing: border-box;
-  border-radius: 4px;
-  font-size: ${rem(14)};
-
-  &:hover {
-    border-color: ${palette.signal.links};
-  }
-
-  ${(props: ToggleElementProps) =>
+export const ToggleElement = styled(Button)<ToggleElementProps>`
+  ${(props) =>
     props.shown &&
     css`
-      background-color: ${palette.pine4};
-      color: white;
-
+      &,
       &:hover {
         background-color: ${palette.pine4};
+        color: ${palette.white};
       }
     `}
 
-  ${(props: ToggleElementProps) =>
+  ${(props) =>
     props.borderless &&
     css`
-      border-width: 0;
+      border-color: transparent;
     `}
 `;
 

--- a/packages/design-system/src/components/Dropdown/Dropdown.styles.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.styles.tsx
@@ -127,28 +127,7 @@ export const MenuElement = styled.div.attrs({
     `}
 `;
 
-interface ToggleElementProps {
-  borderless?: boolean;
-  shown: boolean;
-}
-
-export const ToggleElement = styled(Button)<ToggleElementProps>`
-  ${(props) =>
-    props.shown &&
-    css`
-      &,
-      &:hover {
-        background-color: ${palette.pine4};
-        color: ${palette.white};
-      }
-    `}
-
-  ${(props) =>
-    props.borderless &&
-    css`
-      border-color: transparent;
-    `}
-`;
+export const ToggleElement = styled(Button)``;
 
 export const DropdownElement = styled.div`
   display: inline-block;

--- a/packages/design-system/src/components/Dropdown/Dropdown.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.tsx
@@ -21,7 +21,7 @@ import DropdownFocusManager from "./DropdownFocusManager";
 import DropdownContext from "./DropdownContext";
 import Menu from "./DropdownMenu";
 import MenuItem from "./DropdownMenuItem";
-import Toggle, { ToggleIcon } from "./DropdownToggle";
+import Toggle from "./DropdownToggle";
 import MenuLabel from "./DropdownMenuLabel";
 
 interface DropdownProps {
@@ -47,6 +47,5 @@ Dropdown.Menu = Menu;
 Dropdown.MenuLabel = MenuLabel;
 Dropdown.MenuItem = MenuItem;
 Dropdown.Toggle = Toggle;
-Dropdown.ToggleIcon = ToggleIcon;
 
 export default Dropdown;

--- a/packages/design-system/src/components/Dropdown/DropdownToggle.tsx
+++ b/packages/design-system/src/components/Dropdown/DropdownToggle.tsx
@@ -23,7 +23,6 @@ import { ButtonProps } from "../Button/Button.types";
 
 export interface ToggleProps extends Pick<ButtonProps, "kind" | "shape"> {
   ariaLabel: string;
-  borderless?: boolean;
   children: React.ReactNode;
   className?: string;
   icon?: IconSVGMap[keyof IconSVGMap];
@@ -41,7 +40,6 @@ const ToggleIcon = ({ kind, size }: ToggleIconProps): JSX.Element => {
 const Toggle = ({
   children,
   className,
-  borderless = false,
   ariaLabel,
   shape = "block",
   kind = "secondary",
@@ -57,8 +55,6 @@ const Toggle = ({
           setShown(true);
         }
       }}
-      borderless={borderless}
-      shown={shown}
       aria-label={ariaLabel}
       aria-haspopup="menu"
       aria-expanded={shown}

--- a/packages/design-system/src/components/Dropdown/DropdownToggle.tsx
+++ b/packages/design-system/src/components/Dropdown/DropdownToggle.tsx
@@ -15,40 +15,27 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 import * as React from "react";
-import { IconSVG, IconSVGMap } from "../Icon/IconSVG";
 import DropdownContext from "./DropdownContext";
 import { ToggleElement } from "./Dropdown.styles";
-import { Icon } from "../Icon/Icon";
 import { ButtonProps } from "../Button/Button.types";
 
-export interface ToggleProps extends Pick<ButtonProps, "kind" | "shape"> {
-  ariaLabel: string;
-  children: React.ReactNode;
+export interface ToggleProps extends ButtonProps {
+  ariaLabel?: string;
+  children?: React.ReactNode;
   className?: string;
-  icon?: IconSVGMap[keyof IconSVGMap];
 }
-
-export interface ToggleIconProps {
-  kind: keyof typeof IconSVG | React.FC;
-  size?: string | number;
-}
-
-const ToggleIcon = ({ kind, size }: ToggleIconProps): JSX.Element => {
-  return <Icon kind={kind} size={size} fill="currentColor" />;
-};
 
 const Toggle = ({
   children,
-  className,
   ariaLabel,
   shape = "block",
   kind = "secondary",
+  ...attributes
 }: ToggleProps): JSX.Element => {
   const { shown, setShown } = React.useContext(DropdownContext);
 
   return (
     <ToggleElement
-      className={className}
       onClick={() => setShown(!shown)}
       onKeyPress={(event) => {
         if (event.key === "Down" || event.key === "ArrowDown") {
@@ -60,6 +47,7 @@ const Toggle = ({
       aria-expanded={shown}
       shape={shape}
       kind={kind}
+      {...attributes}
     >
       {children}
     </ToggleElement>
@@ -67,4 +55,3 @@ const Toggle = ({
 };
 
 export default Toggle;
-export { ToggleIcon };

--- a/packages/design-system/src/components/Dropdown/DropdownToggle.tsx
+++ b/packages/design-system/src/components/Dropdown/DropdownToggle.tsx
@@ -19,12 +19,12 @@ import { IconSVG, IconSVGMap } from "../Icon/IconSVG";
 import DropdownContext from "./DropdownContext";
 import { ToggleElement } from "./Dropdown.styles";
 import { Icon } from "../Icon/Icon";
-import { palette } from "../../styles";
+import { ButtonProps } from "../Button/Button.types";
 
-export interface ToggleProps {
+export interface ToggleProps extends Pick<ButtonProps, "kind" | "shape"> {
   ariaLabel: string;
   borderless?: boolean;
-  children: React.ReactNode | React.ReactNode[] | null;
+  children: React.ReactNode;
   className?: string;
   icon?: IconSVGMap[keyof IconSVGMap];
 }
@@ -35,15 +35,7 @@ export interface ToggleIconProps {
 }
 
 const ToggleIcon = ({ kind, size }: ToggleIconProps): JSX.Element => {
-  const { shown } = React.useContext(DropdownContext);
-
-  return (
-    <Icon
-      kind={kind}
-      size={size}
-      fill={shown ? palette.marble1 : palette.signal.links}
-    />
-  );
+  return <Icon kind={kind} size={size} fill="currentColor" />;
 };
 
 const Toggle = ({
@@ -51,6 +43,8 @@ const Toggle = ({
   className,
   borderless = false,
   ariaLabel,
+  shape = "block",
+  kind = "secondary",
 }: ToggleProps): JSX.Element => {
   const { shown, setShown } = React.useContext(DropdownContext);
 
@@ -68,6 +62,8 @@ const Toggle = ({
       aria-label={ariaLabel}
       aria-haspopup="menu"
       aria-expanded={shown}
+      shape={shape}
+      kind={kind}
     >
       {children}
     </ToggleElement>


### PR DESCRIPTION
## Description of the change

- `Button` supports a "block" variant via the new `shape` property, and a new "borderless" kind. All kind values are applied to block buttons the same way they are to "pill" buttons (which is what the existing kind is named now)
- `Dropdown.Toggle` uses these properties of `Button` instead of implementing its own button. (There were slight discrepancies between the "secondary" styles; secondary now uses the newer styles seen in Case Triage and Spotlight with a gray border, and all button kinds have some additional hover states and transitions now for consistency)
- `Button` supports an "icon button" variant via the `icon` property, which will cause it to render only the named icon component as its children. This component is integrated with the button so it picks up color changes from the various button states (it will follow the text color). At a result `Dropdown.ToggleIcon` isn't needed anymore and has been removed. (I was sort of on the fence about this ... we could probably maintain a composition-based approach to integrating these if that would be preferable, though either way I don't think we need a Dropdown-flavored Icon component anymore)

<img width="65" alt="Screen Shot 2021-05-27 at 3 56 26 PM" src="https://user-images.githubusercontent.com/5385319/119906964-22d39c80-bf04-11eb-9951-c6d19b957feb.png">
<img width="54" alt="Screen Shot 2021-05-27 at 3 53 26 PM" src="https://user-images.githubusercontent.com/5385319/119906965-236c3300-bf04-11eb-8f8b-a49afaaacace.png">
<img width="161" alt="Screen Shot 2021-05-27 at 3 53 17 PM" src="https://user-images.githubusercontent.com/5385319/119906967-2404c980-bf04-11eb-8b08-8ba496fba661.png">
<img width="209" alt="Screen Shot 2021-05-27 at 3 57 03 PM" src="https://user-images.githubusercontent.com/5385319/119907002-32eb7c00-bf04-11eb-929b-453552f9f5a5.png">
<img width="226" alt="Screen Shot 2021-05-27 at 4 02 33 PM" src="https://user-images.githubusercontent.com/5385319/119907377-f8361380-bf04-11eb-9a39-928404712820.png">

`Button` takes more arguments now and there are some combinations that negate each other or result in something not that useful; I have tried to document these where they occur but am not currently enforcing any forbidden combos ... none of them should actually break anything, per se, so they are safe as far as that goes.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #27 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
