### PR TITLE
Include `<Toast/>` in `@recidiviz/design-system`

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recidiviz/design-system",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "UI components and styles for Recidiviz web products.",
   "author": "Recidiviz <team@recidiviz.org>",
   "license": "GPL-3.0-only",

--- a/packages/design-system/src/components/Toast/Toast.styles.tsx
+++ b/packages/design-system/src/components/Toast/Toast.styles.tsx
@@ -15,9 +15,12 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 import styled from "styled-components";
-import { AppearanceTypes } from "react-toast-notifications";
+import {
+  AppearanceTypes,
+  DefaultToastContainer,
+} from "react-toast-notifications";
 import { rem } from "polished";
-import { fonts, palette, spacing } from "../../styles";
+import { fonts, palette, spacing, zindex } from "../../styles";
 
 export const ToastBackgroundColors = {
   success: "#d5f6ee",
@@ -32,6 +35,14 @@ export const ToastAccentColors = {
   warning: "#d9a95f",
   error: "#c53b3e",
 };
+
+export const ToastContainer = styled(DefaultToastContainer)`
+  /* additional specificity to override default styles */
+  && {
+    padding: ${rem(spacing.xl)};
+    z-index: ${zindex.toast};
+  }
+`;
 
 export const BaseToastDiv = styled.div<{ appearance: AppearanceTypes }>(
   ({ appearance }) => `

--- a/packages/design-system/src/components/Toast/Toast.tsx
+++ b/packages/design-system/src/components/Toast/Toast.tsx
@@ -27,6 +27,7 @@ import {
   BaseToastDiv,
   IconWrapper,
   ToastAccentColors,
+  ToastContainer,
 } from "./Toast.styles";
 
 const IconMap = {
@@ -70,7 +71,10 @@ export interface ToastProviderProps {
 export const ToastProvider = ({
   children,
 }: ToastProviderProps): JSX.Element => (
-  <OriginalToastProvider placement="bottom-right" components={{ Toast }}>
+  <OriginalToastProvider
+    placement="bottom-right"
+    components={{ Toast, ToastContainer }}
+  >
     {children}
   </OriginalToastProvider>
 );

--- a/packages/design-system/src/components/Toast/Toast.tsx
+++ b/packages/design-system/src/components/Toast/Toast.tsx
@@ -42,7 +42,7 @@ export const Toast: React.FC<ToastProps> = ({ appearance, children }) => (
       <Icon
         kind={IconMap[appearance]}
         size={24}
-        fill={ToastAccentColors[appearance]}
+        color={ToastAccentColors[appearance]}
       />
     </IconWrapper>
     <BaseToastContent>{children}</BaseToastContent>

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -36,4 +36,5 @@ export * from "./components/Modal";
 export * from "./components/Need";
 export * from "./components/Search";
 export * from "./components/Tabs";
+export * from "./components/Toast";
 export * from "./components/Typography";

--- a/packages/design-system/src/styles/zindex.ts
+++ b/packages/design-system/src/styles/zindex.ts
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 export const zindex = {
+  toast: 1002,
   modal: {
     backdrop: 1000,
     content: 1001,


### PR DESCRIPTION
## Description of the change
I'll be adding our first usage of the `<Toast/>` component to case-triage shortly. This exports the components into our package.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)


## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
