### PR TITLE
[Design system] Dropdown extensions

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recidiviz/design-system",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "UI components and styles for Recidiviz web products.",
   "author": "Recidiviz <team@recidiviz.org>",
   "license": "GPL-3.0-only",

--- a/packages/design-system/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.stories.tsx
@@ -63,6 +63,10 @@ export default {
       options: Object.keys(IconSVG),
       control: { type: "select" },
     },
+    showCaret: {
+      name: "DropdownToggle showCaret",
+      type: "boolean",
+    },
   },
 } as Meta;
 
@@ -74,6 +78,7 @@ const Template: Story<CombinedArgs> = ({
   kind,
   shape,
   icon,
+  showCaret,
 }) => {
   const { addToast } = useToasts();
 
@@ -83,7 +88,12 @@ const Template: Story<CombinedArgs> = ({
         other focusable element
       </button>
       <Dropdown>
-        <DropdownToggle kind={kind} shape={shape} icon={icon}>
+        <DropdownToggle
+          kind={kind}
+          shape={shape}
+          icon={icon}
+          showCaret={showCaret}
+        >
           {children}
         </DropdownToggle>
         <DropdownMenu alignment={alignment}>

--- a/packages/design-system/src/components/Dropdown/Dropdown.styles.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.styles.tsx
@@ -37,6 +37,7 @@ export const MenuItemElement = styled.button.attrs({
   text-align: left;
   white-space: nowrap;
   font-size: ${rem(14)};
+  font-family: ${fonts.body};
 
   &:focus {
     outline: none;

--- a/packages/design-system/src/components/Dropdown/Dropdown.styles.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.styles.tsx
@@ -129,6 +129,13 @@ export const MenuElement = styled.div.attrs({
 
 export const ToggleElement = styled(Button)``;
 
+export const CaretWrapper = styled.span`
+  display: inline-flex;
+  margin-left: auto;
+  padding-left: ${rem(spacing.sm)};
+  vertical-align: middle;
+`;
+
 export const DropdownElement = styled.div`
   display: inline-block;
   position: relative;

--- a/packages/design-system/src/components/Dropdown/DropdownMenuItem.tsx
+++ b/packages/design-system/src/components/Dropdown/DropdownMenuItem.tsx
@@ -21,7 +21,7 @@ import DropdownContext from "./DropdownContext";
 
 export interface DropdownMenuItemProps {
   className?: string;
-  label: string;
+  label: React.ReactNode;
   onClick: React.MouseEventHandler<HTMLButtonElement>;
 }
 

--- a/packages/design-system/src/components/Dropdown/DropdownMenuItem.tsx
+++ b/packages/design-system/src/components/Dropdown/DropdownMenuItem.tsx
@@ -21,13 +21,18 @@ import DropdownContext from "./DropdownContext";
 
 export interface DropdownMenuItemProps {
   className?: string;
-  label: React.ReactNode;
+  /**
+   * @deprecated pass children instead
+   */
+  label?: string;
+  children?: React.ReactNode;
   onClick: React.MouseEventHandler<HTMLButtonElement>;
 }
 
 export const DropdownMenuItem = ({
   className,
   label,
+  children,
   onClick,
 }: DropdownMenuItemProps): JSX.Element => {
   const { focusManager, shown, setShown } = useContext(DropdownContext);
@@ -54,7 +59,7 @@ export const DropdownMenuItem = ({
       disabled={!shown}
       tabIndex={-1}
     >
-      {label}
+      {label || children}
     </MenuItemElement>
   );
 };

--- a/packages/design-system/src/components/Dropdown/DropdownToggle.tsx
+++ b/packages/design-system/src/components/Dropdown/DropdownToggle.tsx
@@ -15,19 +15,23 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 import * as React from "react";
+import { rem } from "polished";
 import DropdownContext from "./DropdownContext";
-import { ToggleElement } from "./Dropdown.styles";
+import { CaretWrapper, ToggleElement } from "./Dropdown.styles";
 import { ButtonProps } from "../Button";
+import { Icon } from "../Icon";
 
 export interface DropdownToggleProps extends ButtonProps {
   children?: React.ReactNode;
   className?: string;
+  showCaret?: boolean;
 }
 
 export const DropdownToggle = ({
   children,
   shape = "block",
   kind = "secondary",
+  showCaret,
   ...attributes
 }: DropdownToggleProps): JSX.Element => {
   const { shown, setShown } = React.useContext(DropdownContext);
@@ -48,6 +52,11 @@ export const DropdownToggle = ({
       {...attributes}
     >
       {children}
+      {showCaret && (
+        <CaretWrapper>
+          <Icon kind="DownChevron" height={rem(4)} width={rem(8)} />
+        </CaretWrapper>
+      )}
     </ToggleElement>
   );
 };


### PR DESCRIPTION
## Description of the change

Small changes to the Dropdown component family: 

- optionally render a caret in the toggle button by passing a prop (a common enough feature that we shouldn't have to keep reimplementing it)
- fix incorrect typeface in the menu (was picking up system default from user-agent button styles)
- accept any `ReactNode` as an item label, not just strings

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Related issues

> supports https://github.com/Recidiviz/recidiviz-data/issues/7801

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
