### PR TITLE
[ESLint] Enforce import sort order

### DIFF
--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## v2.0.0
+
+### Added
+
+- activated import and export sorting rules from `simple-import-sort` plugin
+
+## v1.0.0
+
+Initial release

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -90,6 +90,8 @@ module.exports = {
       "error",
       { declaration: false, assignment: false },
     ],
+    "simple-import-sort/imports": "error",
+    "simple-import-sort/exports": "error"
   },
   overrides: [
     {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recidiviz/eslint-config",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Shared ESLint config for Recidiviz web applications",
   "author": "Recidiviz <team@recidiviz.org>",
   "main": "index.js",


### PR DESCRIPTION
## Description of the change

I just realized, thanks to [this PR](https://github.com/Recidiviz/recidiviz-data/pull/8130#discussion_r665709489), that while we were including the `simple-import-sort` plugin here we were never actually applying its rules! This turns them on. 

I'd consider this a breaking change because it will probably introduce lots of linting errors when you update to this downstream; however, they should all be auto-fixable so it shouldn't be a big deal.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

n/a

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
