### PR TITLE
[Design System] Safari dropdown bug

### DIFF
--- a/packages/design-system/CHANGELOG.md
+++ b/packages/design-system/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v2.3.2
+
+### Fixed
+
+- Bug in `Dropdown` where Safari ignored menu item clicks
+
+## v2.3.1
+
+### Added
+
+- `Gift` icon (#42)
+
 ## v2.3.0
 
 ### Added

--- a/packages/design-system/CHANGELOG.md
+++ b/packages/design-system/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Bug in `Dropdown` where Safari ignored menu item clicks
+- Bug in `Dropdown` where Safari ignored menu item clicks (#43)
 
 ## v2.3.1
 

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recidiviz/design-system",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "UI components and styles for Recidiviz web products.",
   "author": "Recidiviz <team@recidiviz.org>",
   "license": "GPL-3.0-only",

--- a/packages/design-system/src/components/Dropdown/DropdownMenuItem.tsx
+++ b/packages/design-system/src/components/Dropdown/DropdownMenuItem.tsx
@@ -50,6 +50,11 @@ export const DropdownMenuItem = ({
     <MenuItemElement
       className={className}
       ref={ref}
+      onMouseDown={(e) =>
+        // prevents a blur from clobbering click event in Safari
+        // https://stackoverflow.com/questions/17769005/onclick-and-onblur-ordering-issue/57630197#57630197
+        e.preventDefault()
+      }
       onMouseEnter={onMouseEnter}
       onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
         onClick(event);


### PR DESCRIPTION
## Description of the change

In Safari, clicking on a dropdown element can sometimes cause the menu to lose focus and close before the click event can actually be handled. This issue is not evident in Storybook but it did appear in real-world use. 

This solution fixes the issue and, as far as I can tell, causes no regressions in targeted browsers, but it's not terribly satisfying. I have not been able to determine:

- why this only affects Safari
- why it happens in the Case Triage application but not in Storybook
- why this even fixes the problem tbh?

I think there is some deeper underlying flaw in the focus management feature that requires some more investigation; I suspect that its internal state gets somehow out of sync with the DOM when the component re-renders but I haven't been able to pin that down after a few hours of debugging, and I need this bugfix to unblock a Case Triage release. (We honestly might want to consider using a well-tested library instead of continuing to maintain our own solution, as this is both difficult and well-trod territory for web applications. Either way, out of scope for now IMO.)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

https://github.com/Recidiviz/recidiviz-data/issues/8235

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
