### PR TITLE
[Design System] position dropdown caret properly in IE11

### DIFF
--- a/packages/design-system/CHANGELOG.md
+++ b/packages/design-system/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Bug in `Dropdown` where Safari ignored menu item clicks (#43)
+- Bug in `Dropdown` where caret was not placed correctly in IE 11 (#44)
 
 ## v2.3.1
 

--- a/packages/design-system/src/components/Dropdown/Dropdown.styles.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.styles.tsx
@@ -132,7 +132,6 @@ export const ToggleElement = styled(Button)``;
 
 export const CaretWrapper = styled.span`
   display: inline-flex;
-  margin-left: auto;
   padding-left: ${rem(spacing.sm)};
   vertical-align: middle;
 `;

--- a/packages/design-system/src/components/Dropdown/DropdownToggle.tsx
+++ b/packages/design-system/src/components/Dropdown/DropdownToggle.tsx
@@ -32,9 +32,15 @@ export const DropdownToggle = ({
   shape = "block",
   kind = "secondary",
   showCaret,
+  style,
   ...attributes
 }: DropdownToggleProps): JSX.Element => {
   const { shown, setShown } = React.useContext(DropdownContext);
+
+  const inlineStyles = { ...style };
+  if (showCaret) {
+    inlineStyles.justifyContent = "space-between";
+  }
 
   return (
     <ToggleElement
@@ -49,6 +55,7 @@ export const DropdownToggle = ({
       shape={shape}
       kind={kind}
       tabIndex={shown ? -1 : 0}
+      style={inlineStyles}
       {...attributes}
     >
       {children}


### PR DESCRIPTION
## Description of the change

IE 11, for whatever reason, does not handle an `auto`margin the same as other browsers, which was breaking the little trick we used to override the centering in a `DropdownToggle` when the caret is displayed. This explicitly overrides the `justify-content` style instead, which has the same end result and works in all browsers. 

<img width="189" alt="Screen Shot 2021-07-14 at 3 34 57 PM" src="https://user-images.githubusercontent.com/5385319/125682214-54106a2f-9b6f-4e7e-844b-7b7db49b2a8e.png">

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

https://github.com/Recidiviz/recidiviz-data/issues/8235

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
