### PR TITLE
[Design System] Accept all library props for ToastProvider

### DIFF
--- a/packages/design-system/CHANGELOG.md
+++ b/packages/design-system/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.5.1
+
+### Fixed
+
+- Accept all library props for ToastProvider (#49)
+
 ## v2.5.0
 
 ### Added

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recidiviz/design-system",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "UI components and styles for Recidiviz web products.",
   "author": "Recidiviz <team@recidiviz.org>",
   "license": "GPL-3.0-only",

--- a/packages/design-system/src/components/Toast/Toast.tsx
+++ b/packages/design-system/src/components/Toast/Toast.tsx
@@ -19,6 +19,7 @@ import {
   Options,
   ToastProps,
   ToastProvider as OriginalToastProvider,
+  ToastProviderProps,
   useToasts as useToastsOrig,
 } from "react-toast-notifications";
 import { Icon } from "../Icon";
@@ -64,16 +65,14 @@ export const useToasts = (): ReturnType<typeof useToastsOrig> => {
   return { addToast: addToastWrapper, ...others };
 };
 
-export interface ToastProviderProps {
-  children: React.ReactNode;
-}
-
 export const ToastProvider = ({
   children,
+  ...props
 }: ToastProviderProps): JSX.Element => (
   <OriginalToastProvider
     placement="bottom-right"
     components={{ Toast, ToastContainer }}
+    {...props}
   >
     {children}
   </OriginalToastProvider>
@@ -82,6 +81,7 @@ export const ToastProvider = ({
 export type {
   AppearanceTypes as ToastType,
   ToastProps,
+  ToastProviderProps,
 } from "react-toast-notifications";
 
 export default Toast;


### PR DESCRIPTION
## Description of the change

Accept all props for ToastProvider and pass them through to the underlying library. Some options (e.g. toast placement) can only be set at the provider level; this enables that while preserving the defaults we set in our wrapper component.

## Type of change

- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> https://github.com/Recidiviz/recidiviz-data/issues/8500 (blocks https://github.com/Recidiviz/recidiviz-data/pull/8556)

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
