### PR TITLE
[Design System] Hide TabPanels that are not selected

### DIFF
--- a/packages/design-system/CHANGELOG.md
+++ b/packages/design-system/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.5.2
+
+### Fixed
+
+- Hide inactive TabPanels so they don't interfere with the active one (#50)
+
 ## v2.5.1
 
 ### Fixed

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recidiviz/design-system",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "UI components and styles for Recidiviz web products.",
   "author": "Recidiviz <team@recidiviz.org>",
   "license": "GPL-3.0-only",

--- a/packages/design-system/src/components/Tabs/Tabs.styles.tsx
+++ b/packages/design-system/src/components/Tabs/Tabs.styles.tsx
@@ -60,9 +60,9 @@ export const TabPanel = styled(ReactTabs.TabPanel).attrs({
   selectedClassName: "TabPanel--selected",
 })`
   display: none;
+  padding: ${rem(spacing.xl)};
 
   &.TabPanel--selected {
     display: block;
-    padding: ${rem(spacing.xl)};
   }
 `;

--- a/packages/design-system/src/components/Tabs/Tabs.styles.tsx
+++ b/packages/design-system/src/components/Tabs/Tabs.styles.tsx
@@ -59,7 +59,10 @@ export const Tab = styled(ReactTabs.Tab).attrs({
 export const TabPanel = styled(ReactTabs.TabPanel).attrs({
   selectedClassName: "TabPanel--selected",
 })`
+  display: none;
+
   &.TabPanel--selected {
+    display: block;
     padding: ${rem(spacing.xl)};
   }
 `;


### PR DESCRIPTION
## Description of the change

`TabPanel` components that are not selected may still take up space even though they don't have contents; this may depend on the container styles or even overrides but it's not an uncommon situation. Most browsers seem to be able to handle this but IE 11 does not: invisible tabs may be rendered on top of the active one and intercept mouse events, preventing interaction with the active tab. 

The most hygienic solution (and the one seen in examples provided by React Tabs documentation) is to simply hide tabpanels that don't have the `selected` class applied to them, so that's what I've done here!

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

https://github.com/Recidiviz/recidiviz-data/issues/8645

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
