### PR TITLE
Update `<Button/>` props structure to allow for `HTMLButtonElement` attributes

### DIFF
--- a/packages/design-system/CHANGELOG.md
+++ b/packages/design-system/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v2.6.2
+
+### Configuration Change
+
+- Improved `<Button/>` component typing to allow `type` attribute (#64)
+
+
 ## v2.6.1
 
 ### Configuration Change

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recidiviz/design-system",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "UI components and styles for Recidiviz web products.",
   "author": "Recidiviz <team@recidiviz.org>",
   "license": "GPL-3.0-only",

--- a/packages/design-system/src/components/Button/Button.styles.tsx
+++ b/packages/design-system/src/components/Button/Button.styles.tsx
@@ -90,9 +90,7 @@ const borderlessStyles = css`
   }
 `;
 
-export const BaseButton = styled.button.attrs({
-  type: "button",
-})<Pick<ButtonProps, "kind" | "shape">>`
+export const BaseButton = styled.button<Pick<ButtonProps, "kind" | "shape">>`
   align-items: center;
   cursor: pointer;
   display: flex;
@@ -131,9 +129,7 @@ export const BaseButton = styled.button.attrs({
   }}
 `;
 
-export const LinkButton = styled.button.attrs({
-  type: "button",
-})<ButtonProps>`
+export const LinkButton = styled.button<ButtonProps>`
   background: transparent;
   border: none;
   color: ${palette.signal.links};

--- a/packages/design-system/src/components/Button/Button.tsx
+++ b/packages/design-system/src/components/Button/Button.tsx
@@ -30,6 +30,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       onClick,
       icon,
       iconSize = 16,
+      type = "button",
       ...attributes
     },
     ref
@@ -43,6 +44,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         disabled={disabled}
         shape={shape}
         kind={kind}
+        type={type}
         {...attributes}
         ref={ref}
       >

--- a/packages/design-system/src/components/Button/Button.types.ts
+++ b/packages/design-system/src/components/Button/Button.types.ts
@@ -20,7 +20,8 @@ import { IconSVG } from "../Icon";
 export type ButtonKind = "primary" | "secondary" | "link" | "borderless";
 export type ButtonShape = "pill" | "block";
 
-export interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   /**
    * children will not be rendered if an icon is specified
    */


### PR DESCRIPTION
## Description of the change

Using `React.HTMLAttributes<HTMLButtonElement>` does not include typings for the attributes of an `HTMLButtonElement` as I had previously thought. This patch uses `React.HTMLButtonAttributes` which includes these additional typings:
```typescript
    interface ButtonHTMLAttributes<T> extends HTMLAttributes<T> {
        autoFocus?: boolean;
        disabled?: boolean;
        form?: string;
        formAction?: string;
        formEncType?: string;
        formMethod?: string;
        formNoValidate?: boolean;
        formTarget?: string;
        name?: string;
        type?: 'submit' | 'reset' | 'button';
        value?: string | ReadonlyArray<string> | number;
    }
```

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
