### PR TITLE
[design-system] Add a Tooltip component

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -33,6 +33,7 @@
     "prop-types": "^15.7.2",
     "react-is": "^17.0.2",
     "react-modal": "^3.12.1",
+    "react-spring": "^9.4.3",
     "react-tabs": "^3.2.2",
     "react-toast-notifications": "^2.4.3",
     "styled-components": "^5.2.1"

--- a/packages/design-system/src/components/ChartWrapper/ChartWrapper.stories.mdx
+++ b/packages/design-system/src/components/ChartWrapper/ChartWrapper.stories.mdx
@@ -22,6 +22,7 @@ import { cityTemperature, exoplanets, letterFrequency } from "@visx/mock-data";
 import { OrdinalFrame, XYFrame } from "semiotic";
 import { palette } from "../../styles";
 import { ChartWrapper } from "./ChartWrapper";
+import { Tooltip } from "../Tooltip";
 
 <Meta
   title="Design System/Charts"
@@ -391,8 +392,7 @@ computing some positioning offsets on the fly in the tooltip rendering function.
       size={[600, 300]}
       tooltipContent={(d) => {
         return (
-          <div
-            className="tooltip-content"
+          <Tooltip
             style={{
               // e.g., counteract the Y offset
               // so the tooltip doesn't jump up and down
@@ -402,7 +402,7 @@ computing some positioning offsets on the fly in the tooltip rendering function.
             <div>
               {d.summary[0].column}: {d.summary[0].value}
             </div>
-          </div>
+          </Tooltip>
         );
       }}
       type="bar"

--- a/packages/design-system/src/components/ChartWrapper/ChartWrapper.tsx
+++ b/packages/design-system/src/components/ChartWrapper/ChartWrapper.tsx
@@ -15,10 +15,10 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { rem } from "polished";
 import * as React from "react";
 import styled from "styled-components";
-import { palette, zindex } from "../../styles";
+import { palette } from "../../styles";
+import { tooltipStyles } from "../Tooltip";
 
 const SemioticWrapper = styled.div`
   /* classes provided by Semiotic */
@@ -75,14 +75,7 @@ const SemioticWrapper = styled.div`
     }
 
     .tooltip-content {
-      background: ${palette.pine1};
-      border-radius: ${rem(4)};
-      box-shadow: 0 ${rem(2)} ${rem(10)} rgba(0, 0, 0, 0.1);
-      color: ${palette.marble1};
-      font-size: ${rem(14)};
-      min-width: ${rem(120)};
-      padding: ${rem(16)};
-      z-index: ${zindex.tooltip};
+      ${tooltipStyles}
     }
 
     .xyframe-matte {

--- a/packages/design-system/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/design-system/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,0 +1,53 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import React from "react";
+import { Story, Meta } from "@storybook/react";
+import Tooltip from "./Tooltip";
+
+export default {
+  title: "Design System/Components/Tooltip",
+  parameters: {
+    docs: {
+      // Render inside an iframe so that `position: fixed`; is contained
+      inlineStories: false,
+      iframeHeight: "300px",
+    },
+  },
+
+  argTypes: {
+    show: {
+      description: "Tooltip visibility",
+      control: "boolean",
+    },
+    contents: {
+      description: "Tooltip contents",
+      control: "text",
+    },
+  },
+} as Meta;
+
+const Template: Story = ({ show, contents }) => (
+  <Tooltip
+    state={show ? "entering" : "exiting"}
+    dangerouslySetInnerHTML={{ __html: contents }}
+  />
+);
+
+export const DefaultStory = Template.bind({});
+DefaultStory.args = { show: true, contents: "This is a tooltip" };
+DefaultStory.storyName = "Tooltip";

--- a/packages/design-system/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/design-system/src/components/Tooltip/Tooltip.stories.tsx
@@ -21,19 +21,7 @@ import Tooltip from "./Tooltip";
 
 export default {
   title: "Design System/Components/Tooltip",
-  parameters: {
-    docs: {
-      // Render inside an iframe so that `position: fixed`; is contained
-      inlineStories: false,
-      iframeHeight: "300px",
-    },
-  },
-
   argTypes: {
-    show: {
-      description: "Tooltip visibility",
-      control: "boolean",
-    },
     contents: {
       description: "Tooltip contents",
       control: "text",
@@ -42,12 +30,9 @@ export default {
 } as Meta;
 
 const Template: Story = ({ show, contents }) => (
-  <Tooltip
-    state={show ? "entering" : "exiting"}
-    dangerouslySetInnerHTML={{ __html: contents }}
-  />
+  <Tooltip dangerouslySetInnerHTML={{ __html: contents }} />
 );
 
 export const DefaultStory = Template.bind({});
-DefaultStory.args = { show: true, contents: "This is a tooltip" };
+DefaultStory.args = { contents: "This is a tooltip" };
 DefaultStory.storyName = "Tooltip";

--- a/packages/design-system/src/components/Tooltip/Tooltip.tsx
+++ b/packages/design-system/src/components/Tooltip/Tooltip.tsx
@@ -1,0 +1,47 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+import { rem } from "polished";
+import React from "react";
+import styled from "styled-components";
+import { palette, spacing, zindex } from "../../styles";
+
+const StateStyles = {
+  entering: `opacity: 1;`,
+  exiting: `opacity: 0;`,
+};
+
+export type TooltipState = "entering" | "exiting" | null;
+
+const Tooltip = styled.div<{
+  state: TooltipState;
+}>`
+  display: block;
+  position: fixed;
+  font-size: ${rem("14px")};
+  padding: ${rem(spacing.sm)};
+  border-radius: 4px;
+  color: ${palette.white};
+  background-color: ${palette.signal.tooltip};
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.3s ease-in-out;
+  z-index: ${zindex.modal.content + 1};
+
+  ${(props) => props.state && StateStyles[props.state]}
+`;
+
+export default Tooltip;

--- a/packages/design-system/src/components/Tooltip/Tooltip.tsx
+++ b/packages/design-system/src/components/Tooltip/Tooltip.tsx
@@ -15,20 +15,10 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 import { rem } from "polished";
-import React from "react";
 import styled from "styled-components";
 import { palette, spacing, zindex } from "../../styles";
 
-const StateStyles = {
-  entering: `opacity: 1;`,
-  exiting: `opacity: 0;`,
-};
-
-export type TooltipState = "entering" | "exiting" | null;
-
-const Tooltip = styled.div<{
-  state: TooltipState;
-}>`
+const Tooltip = styled.div`
   display: block;
   position: fixed;
   font-size: ${rem("14px")};
@@ -37,11 +27,7 @@ const Tooltip = styled.div<{
   color: ${palette.white};
   background-color: ${palette.signal.tooltip};
   pointer-events: none;
-  opacity: 0;
-  transition: opacity 0.3s ease-in-out;
   z-index: ${zindex.modal.content + 1};
-
-  ${(props) => props.state && StateStyles[props.state]}
 `;
 
 export default Tooltip;

--- a/packages/design-system/src/components/Tooltip/Tooltip.tsx
+++ b/packages/design-system/src/components/Tooltip/Tooltip.tsx
@@ -15,10 +15,10 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 import { rem } from "polished";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import { palette, spacing, zindex } from "../../styles";
 
-const Tooltip = styled.div`
+export const tooltipStyles = css`
   display: block;
   position: fixed;
   font-size: ${rem("14px")};
@@ -30,4 +30,6 @@ const Tooltip = styled.div`
   z-index: ${zindex.modal.content + 1};
 `;
 
-export default Tooltip;
+export const Tooltip = styled.div`
+  ${tooltipStyles}
+`;

--- a/packages/design-system/src/components/Tooltip/TooltipTrigger.stories.tsx
+++ b/packages/design-system/src/components/Tooltip/TooltipTrigger.stories.tsx
@@ -34,7 +34,7 @@ export default {
 const Template: Story = ({ contents }) => (
   <TooltipTrigger
     // eslint-disable-next-line react/no-danger
-    title={<span dangerouslySetInnerHTML={{ __html: contents }} />}
+    contents={<span dangerouslySetInnerHTML={{ __html: contents }} />}
   >
     <Button>Hover me</Button>
   </TooltipTrigger>

--- a/packages/design-system/src/components/Tooltip/TooltipTrigger.stories.tsx
+++ b/packages/design-system/src/components/Tooltip/TooltipTrigger.stories.tsx
@@ -1,0 +1,57 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import React from "react";
+import { Story, Meta } from "@storybook/react";
+import TooltipTrigger from "./TooltipTrigger";
+import { Button } from "../Button";
+
+export default {
+  title: "Design System/Components/Tooltip Trigger",
+  component: TooltipTrigger,
+  parameters: {
+    docs: {
+      // Render inside an iframe so that `position: fixed`; is contained
+      inlineStories: false,
+      iframeHeight: "300px",
+    },
+  },
+
+  argTypes: {
+    show: {
+      description: "Tooltip visibility",
+      control: "boolean",
+    },
+    contents: {
+      description: "Tooltip contents",
+      control: "text",
+    },
+  },
+} as Meta;
+
+const Template: Story = ({ contents }) => (
+  <TooltipTrigger
+    // eslint-disable-next-line react/no-danger
+    title={<span dangerouslySetInnerHTML={{ __html: contents }} />}
+  >
+    <Button>Hover me</Button>
+  </TooltipTrigger>
+);
+
+export const DefaultStory = Template.bind({});
+DefaultStory.args = { contents: "This is a tooltip" };
+DefaultStory.storyName = "Tooltip Trigger";

--- a/packages/design-system/src/components/Tooltip/TooltipTrigger.stories.tsx
+++ b/packages/design-system/src/components/Tooltip/TooltipTrigger.stories.tsx
@@ -17,7 +17,7 @@
 
 import React from "react";
 import { Story, Meta } from "@storybook/react";
-import TooltipTrigger from "./TooltipTrigger";
+import { TooltipTrigger } from "./TooltipTrigger";
 import { Button } from "../Button";
 
 export default {

--- a/packages/design-system/src/components/Tooltip/TooltipTrigger.stories.tsx
+++ b/packages/design-system/src/components/Tooltip/TooltipTrigger.stories.tsx
@@ -23,19 +23,7 @@ import { Button } from "../Button";
 export default {
   title: "Design System/Components/Tooltip Trigger",
   component: TooltipTrigger,
-  parameters: {
-    docs: {
-      // Render inside an iframe so that `position: fixed`; is contained
-      inlineStories: false,
-      iframeHeight: "300px",
-    },
-  },
-
   argTypes: {
-    show: {
-      description: "Tooltip visibility",
-      control: "boolean",
-    },
     contents: {
       description: "Tooltip contents",
       control: "text",

--- a/packages/design-system/src/components/Tooltip/TooltipTrigger.tsx
+++ b/packages/design-system/src/components/Tooltip/TooltipTrigger.tsx
@@ -21,10 +21,10 @@ import styled from "styled-components";
 
 import { Tooltip } from "./Tooltip";
 
-interface TooltipTriggerProps {
+type TooltipTriggerProps = {
   children: React.ReactElement;
-  title: React.ReactNode;
-}
+  contents: React.ReactNode;
+};
 
 const AnimatedTooltip = animated(Tooltip);
 
@@ -38,6 +38,17 @@ const HoverTarget = styled.span`
   }
 `;
 
+// only makes a tooltip visible on hover if contents are actually provided
+function useTooltipState(contents: TooltipTriggerProps["contents"]) {
+  const haveValidContents = Boolean(contents);
+  const [showTooltip, setShowTooltip] = React.useState(false);
+  const setShowTooltipIfValid = (hoverState: boolean) => {
+    setShowTooltip(haveValidContents && hoverState);
+  };
+
+  return [showTooltip, setShowTooltipIfValid] as const;
+}
+
 /**
  * Wraps a component that should display a tooltip on hover.
  * `children` must render an element (not just text)
@@ -45,16 +56,17 @@ const HoverTarget = styled.span`
  */
 export const TooltipTrigger: React.FC<TooltipTriggerProps> = ({
   children,
-  title,
+  contents,
 }: TooltipTriggerProps) => {
   const [offset, setOffset] = React.useState({ top: "0px", left: "0px" });
-  const [shouldRenderTooltip, setShouldRenderTooltip] = React.useState(false);
+  // Event handlers should not be
+  const [showTooltip, setShowTooltip] = useTooltipState(contents);
 
-  const transitions = useTransition(shouldRenderTooltip, {
+  const transitions = useTransition(showTooltip, {
     from: { opacity: 0 },
     enter: { opacity: 1 },
     leave: { opacity: 0 },
-    reverse: shouldRenderTooltip,
+    reverse: showTooltip,
     config: {
       mass: 0.75,
       tension: 250,
@@ -77,11 +89,11 @@ export const TooltipTrigger: React.FC<TooltipTriggerProps> = ({
   };
 
   const onMouseEnter = () => {
-    setShouldRenderTooltip(true);
+    setShowTooltip(true);
   };
 
   const onMouseLeave = () => {
-    setShouldRenderTooltip(false);
+    setShowTooltip(false);
   };
 
   return (
@@ -93,7 +105,7 @@ export const TooltipTrigger: React.FC<TooltipTriggerProps> = ({
               <AnimatedTooltip
                 style={{ ...styles, top: offset.top, left: offset.left }}
               >
-                {title}
+                {contents}
               </AnimatedTooltip>
             )
         ),

--- a/packages/design-system/src/components/Tooltip/TooltipTrigger.tsx
+++ b/packages/design-system/src/components/Tooltip/TooltipTrigger.tsx
@@ -1,0 +1,88 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+import React from "react";
+import ReactDOM from "react-dom";
+
+import Tooltip, { TooltipState } from "./Tooltip";
+
+interface TooltipTriggerProps {
+  children: React.ReactNode | React.ReactChild | React.ReactChild[];
+  title: React.ReactNode;
+}
+
+const TooltipTrigger: React.FC<TooltipTriggerProps> = ({
+  children,
+  title,
+}: TooltipTriggerProps) => {
+  const [offset, setOffset] = React.useState({ top: "0px", left: "0px" });
+  const [shouldRenderTooltip, setShouldRenderTooltip] = React.useState(false);
+  const [animationState, setAnimationState] = React.useState<TooltipState>(
+    null
+  );
+
+  let frame: number;
+  const onMouseMove: React.MouseEventHandler<HTMLDivElement> = (event) => {
+    if (typeof frame !== "undefined") {
+      window.cancelAnimationFrame(frame);
+    }
+    frame = window.requestAnimationFrame(() => {
+      setOffset({
+        left: `${event.clientX + 15}px`,
+        top: `${event.clientY + 15}px`,
+      });
+    });
+  };
+
+  const onMouseEnter = () => {
+    setShouldRenderTooltip(true);
+    setAnimationState("entering");
+  };
+
+  const onMouseLeave = () => {
+    setAnimationState("exiting");
+    setShouldRenderTooltip(false);
+  };
+
+  let tooltip = null;
+  if (shouldRenderTooltip) {
+    tooltip = ReactDOM.createPortal(
+      <Tooltip
+        state={animationState}
+        style={{ top: offset.top, left: offset.left }}
+      >
+        {title}
+      </Tooltip>,
+      window.document.body
+    );
+  }
+
+  return (
+    <>
+      {tooltip}
+
+      <span
+        onMouseMove={onMouseMove}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+      >
+        {children}
+      </span>
+    </>
+  );
+};
+
+export default TooltipTrigger;

--- a/packages/design-system/src/components/Tooltip/TooltipTrigger.tsx
+++ b/packages/design-system/src/components/Tooltip/TooltipTrigger.tsx
@@ -19,7 +19,7 @@ import ReactDOM from "react-dom";
 import { useTransition, animated } from "react-spring";
 import styled from "styled-components";
 
-import Tooltip from "./Tooltip";
+import { Tooltip } from "./Tooltip";
 
 interface TooltipTriggerProps {
   children: React.ReactElement;
@@ -28,6 +28,8 @@ interface TooltipTriggerProps {
 
 const AnimatedTooltip = animated(Tooltip);
 
+// if the child is not perfectly rectangular (e.g. has rounded corners),
+// this ensures only the child's footprint will be hoverable and not the space around it
 const HoverTarget = styled.span`
   pointer-events: none;
 
@@ -41,7 +43,7 @@ const HoverTarget = styled.span`
  * `children` must render an element (not just text)
  * so we can properly target it with pointer events.
  */
-const TooltipTrigger: React.FC<TooltipTriggerProps> = ({
+export const TooltipTrigger: React.FC<TooltipTriggerProps> = ({
   children,
   title,
 }: TooltipTriggerProps) => {
@@ -108,5 +110,3 @@ const TooltipTrigger: React.FC<TooltipTriggerProps> = ({
     </>
   );
 };
-
-export default TooltipTrigger;

--- a/packages/design-system/src/components/Tooltip/index.tsx
+++ b/packages/design-system/src/components/Tooltip/index.tsx
@@ -15,24 +15,5 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import React from "react";
-import { Story, Meta } from "@storybook/react";
-import { Tooltip } from "./Tooltip";
-
-export default {
-  title: "Design System/Components/Tooltip",
-  argTypes: {
-    contents: {
-      description: "Tooltip contents",
-      control: "text",
-    },
-  },
-} as Meta;
-
-const Template: Story = ({ show, contents }) => (
-  <Tooltip dangerouslySetInnerHTML={{ __html: contents }} />
-);
-
-export const DefaultStory = Template.bind({});
-DefaultStory.args = { contents: "This is a tooltip" };
-DefaultStory.storyName = "Tooltip";
+export * from "./Tooltip";
+export * from "./TooltipTrigger";

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -37,5 +37,6 @@ export * from "./components/Need";
 export * from "./components/Search";
 export * from "./components/Tabs";
 export * from "./components/Toast";
+export * from "./components/Tooltip";
 export * from "./components/Typography";
 export * from "./components/Loading";

--- a/packages/design-system/yarn.lock
+++ b/packages/design-system/yarn.lock
@@ -1361,6 +1361,92 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
+"@react-spring/animated@~9.4.3-beta.0":
+  version "9.4.3"
+  resolved "https://registry.yarnpkg.com/@react-spring/animated/-/animated-9.4.3.tgz#2f8d2b50dfc1975fa490ed3bc03f5ad865180866"
+  integrity sha512-hKKmeXPoGpJ/zrG/RC8stwW8PmMH0BbewHD8aUPLbyzD9fNvZEJ0mjKmOI0CcSwMpb43kuwY2nX3ZJVImPQCoQ==
+  dependencies:
+    "@react-spring/shared" "~9.4.3-beta.0"
+    "@react-spring/types" "~9.4.3-beta.0"
+
+"@react-spring/core@~9.4.3-beta.0":
+  version "9.4.3"
+  resolved "https://registry.yarnpkg.com/@react-spring/core/-/core-9.4.3.tgz#95c883fa53ff534ff882ba42f863a26a26a6a1c8"
+  integrity sha512-Jr6/GjHwXYxAtttcYDXOtH36krO0XGjYaSsGR6g+vOUO4y0zAPPXoAwpK6vS7Haip5fRwk7rMdNG+OzU7bB4Bg==
+  dependencies:
+    "@react-spring/animated" "~9.4.3-beta.0"
+    "@react-spring/rafz" "~9.4.3-beta.0"
+    "@react-spring/shared" "~9.4.3-beta.0"
+    "@react-spring/types" "~9.4.3-beta.0"
+
+"@react-spring/konva@~9.4.3-beta.0":
+  version "9.4.3"
+  resolved "https://registry.yarnpkg.com/@react-spring/konva/-/konva-9.4.3.tgz#ef5332fc0960fa4313ac0ab6a122fd9247b3b111"
+  integrity sha512-JWxx0YIwipjJTDs7q9XtArlBCTjejyAJZrbhvxmizOM6ZukUj8hcEFYU03Vt5HUTSC4WfG0rkg2O9V1EAXuzCQ==
+  dependencies:
+    "@react-spring/animated" "~9.4.3-beta.0"
+    "@react-spring/core" "~9.4.3-beta.0"
+    "@react-spring/shared" "~9.4.3-beta.0"
+    "@react-spring/types" "~9.4.3-beta.0"
+
+"@react-spring/native@~9.4.3-beta.0":
+  version "9.4.3"
+  resolved "https://registry.yarnpkg.com/@react-spring/native/-/native-9.4.3.tgz#748ee1f588c1515a76766e319aa48151308bd5ad"
+  integrity sha512-dfOwzSxJcbHKTNJ26pceZ7xCrqf2+L6W/U17/7aogQwGec4yf1zocWXV3QS+h0HDuY0Bk/yYa7PEy+D+HWc7Og==
+  dependencies:
+    "@react-spring/animated" "~9.4.3-beta.0"
+    "@react-spring/core" "~9.4.3-beta.0"
+    "@react-spring/shared" "~9.4.3-beta.0"
+    "@react-spring/types" "~9.4.3-beta.0"
+
+"@react-spring/rafz@~9.4.3-beta.0":
+  version "9.4.3"
+  resolved "https://registry.yarnpkg.com/@react-spring/rafz/-/rafz-9.4.3.tgz#0d578072c9692ef5ab74a3b1d49c1432dce32ab6"
+  integrity sha512-KnujiZNIHzXsRq1D4tVbCajl8Lx+e6vtvUk7o69KbuneSpEgil9P/x3b+hMDk8U0NHGhJjzhU7723/CNsQansA==
+
+"@react-spring/shared@~9.4.3-beta.0":
+  version "9.4.3"
+  resolved "https://registry.yarnpkg.com/@react-spring/shared/-/shared-9.4.3.tgz#86e03ddd47911ba89be1d0f5a6d11966e305ee04"
+  integrity sha512-mB1UUD/pl1LzaY0XeNWZtvJzxMa8gLQf02nY12HAz4Rukm9dFRj0jeYwQYLdfYLsGFo1ldvHNurun6hZMG7kiQ==
+  dependencies:
+    "@react-spring/rafz" "~9.4.3-beta.0"
+    "@react-spring/types" "~9.4.3-beta.0"
+
+"@react-spring/three@~9.4.3-beta.0":
+  version "9.4.3"
+  resolved "https://registry.yarnpkg.com/@react-spring/three/-/three-9.4.3.tgz#1836ea12f7cb7ccb4c4a1f39101f4fb17955c386"
+  integrity sha512-AhCPqoZZXUnzVcKal01sdYBRqkVd2iNxDMk7BGXZsQNWeqaOMaaBT/a6d3oG3wwPX6xIa9ogBtzmzEasN6HYzA==
+  dependencies:
+    "@react-spring/animated" "~9.4.3-beta.0"
+    "@react-spring/core" "~9.4.3-beta.0"
+    "@react-spring/shared" "~9.4.3-beta.0"
+    "@react-spring/types" "~9.4.3-beta.0"
+
+"@react-spring/types@~9.4.3-beta.0":
+  version "9.4.3"
+  resolved "https://registry.yarnpkg.com/@react-spring/types/-/types-9.4.3.tgz#8926d7a09812374127b1f8a904a755c7579124e6"
+  integrity sha512-dzJrPvUc42K2un9y6D1IsrPQO5tKsbWwUo+wsATnXjG3ePWyuDBIOMJuPe605NhIXUmPH+Vik2wMoZz06hD1uA==
+
+"@react-spring/web@~9.4.3-beta.0":
+  version "9.4.3"
+  resolved "https://registry.yarnpkg.com/@react-spring/web/-/web-9.4.3.tgz#b59c1491de344545590598b7fde52b607c4e5d10"
+  integrity sha512-llKve/uJ73JVagBAVvA74S/LfZP4oSB3XP1qmggSUNXzPZZo5ylIMrs55PxpLyxgzzihuhDU5N17ct3ATViOHw==
+  dependencies:
+    "@react-spring/animated" "~9.4.3-beta.0"
+    "@react-spring/core" "~9.4.3-beta.0"
+    "@react-spring/shared" "~9.4.3-beta.0"
+    "@react-spring/types" "~9.4.3-beta.0"
+
+"@react-spring/zdog@~9.4.3-beta.0":
+  version "9.4.3"
+  resolved "https://registry.yarnpkg.com/@react-spring/zdog/-/zdog-9.4.3.tgz#0a76564ea635ab00a1720a3843faf4f46ca3c82a"
+  integrity sha512-ujRJBKEWC6miwPhCwHkn13h9OfqK+Kkq49crebo5neY4kCK2efNoagQo54DwXFgbVNFJV+6GwcAZVI2ybS5L1Q==
+  dependencies:
+    "@react-spring/animated" "~9.4.3-beta.0"
+    "@react-spring/core" "~9.4.3-beta.0"
+    "@react-spring/shared" "~9.4.3-beta.0"
+    "@react-spring/types" "~9.4.3-beta.0"
+
 "@recidiviz/eslint-config@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@recidiviz/eslint-config/-/eslint-config-1.0.0.tgz#cdfcb43cb4c85ebf45a2cb8150ce68154781f2ed"
@@ -9801,6 +9887,18 @@ react-sizeme@^3.0.1:
     invariant "^2.2.4"
     shallowequal "^1.1.0"
     throttle-debounce "^3.0.1"
+
+react-spring@^9.4.3:
+  version "9.4.3"
+  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-9.4.3.tgz#3f697d3d6e990dbf7d182619dc75a72a63a302c1"
+  integrity sha512-GGKAqQQ790JLoA2SAUgdJErFRG8oFR6pzX8jnJoqORVWX5Wo9bJUWs4563f2oN19+yQkVhc77neAkqQ7GCN8Lw==
+  dependencies:
+    "@react-spring/core" "~9.4.3-beta.0"
+    "@react-spring/konva" "~9.4.3-beta.0"
+    "@react-spring/native" "~9.4.3-beta.0"
+    "@react-spring/three" "~9.4.3-beta.0"
+    "@react-spring/web" "~9.4.3-beta.0"
+    "@react-spring/zdog" "~9.4.3-beta.0"
 
 react-syntax-highlighter@^13.5.3:
   version "13.5.3"


### PR DESCRIPTION
## Description of the change

This adopts the `Tooltip` component from the Case Triage application and splits it into two components: 
- `Tooltip` is the tooltip itself
- `TooltipTrigger` wraps a hoverable target and encapsulates the logic for showing and hiding the tooltip based on hover state

The behavior and appearance is mostly identical to Case Triage with some small exceptions: 
- there were animation styles in the original that didn't actually work; I have reimplemented fade in/out animations with React Spring. (Some other incoming components will probably use this library also so I think it's worth adding the dependency now.)
- If you pass it empty contents, it won't render a tooltip. (Previously it would render an empty one, which was never what we wanted.)

There is a use case for `Tooltip` on its own to be found in the docs for `ChartWrapper` here; other applications using Semiotic could do the same basic thing. There is also a proof-of-concept implementation using the new `TooltipTrigger` in Case Triage in https://github.com/Recidiviz/recidiviz-data/pull/11401.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Related issues

> Closes #66 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
