### PR TITLE
Add a Pill component

### DIFF
--- a/packages/design-system/src/components/Pill/Pill.stories.tsx
+++ b/packages/design-system/src/components/Pill/Pill.stories.tsx
@@ -1,0 +1,74 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import React from "react";
+import { Story, Meta } from "@storybook/react";
+import { Pill as PillComponent, PillProps } from "./Pill";
+
+export default {
+  title: "Design System/Components/Pill",
+  component: PillComponent,
+  parameters: {
+    controls: {
+      include: ["innerText", "color", "filled", "textColor"],
+    },
+  },
+  argTypes: {
+    innerText: {
+      type: "string",
+    },
+    color: {
+      description:
+        "Sets color for `background-color` if `filled` is true, `border-color` if `filled` is false or is not explicitly defined",
+      type: "string",
+      control: "color",
+    },
+    filled: {
+      description:
+        "Fills `background-color` when true. True if set explicitly or defined as a prop `<Pill filled={true}>` or `<Pill filled>`, false if set explicitly or undefined as a prop `<Pill filled={false}>` or `<Pill>`",
+      type: "boolean",
+    },
+    textColor: {
+      description:
+        "Sets text `color`. If `textColor` is undefined as a prop and `filled` is true, it will default to a light text color. This can be overridden by setting `textColor` to a color value",
+      type: "string",
+      control: "color",
+    },
+  },
+} as Meta;
+
+const Template: Story<PillProps & { innerText: string }> = ({
+  color,
+  filled,
+  textColor,
+  innerText,
+}) => {
+  return (
+    <PillComponent color={color} filled={filled} textColor={textColor}>
+      {innerText}
+    </PillComponent>
+  );
+};
+
+export const Pill: Story<PillProps & { innerText: string }> = Template.bind({});
+
+Pill.args = {
+  innerText: "I am a Pill",
+  color: "rgb(53, 83, 98)",
+  filled: false,
+  textColor: undefined,
+};

--- a/packages/design-system/src/components/Pill/Pill.tsx
+++ b/packages/design-system/src/components/Pill/Pill.tsx
@@ -25,11 +25,7 @@ export type PillProps = {
   textColor?: string;
 };
 
-export const pillPropsToStyles = ({
-  color,
-  filled,
-  textColor,
-}: PillProps): string => {
+const pillPropsToStyles = ({ color, filled, textColor }: PillProps): string => {
   const property = filled ? "background-color" : "border-color";
   const textColorValue = textColor
     ? `color: ${textColor}`

--- a/packages/design-system/src/components/Pill/Pill.tsx
+++ b/packages/design-system/src/components/Pill/Pill.tsx
@@ -1,0 +1,58 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import { rem } from "polished";
+import styled from "styled-components";
+import { palette, spacing } from "../../styles";
+
+export type PillProps = {
+  color: string;
+  filled?: boolean;
+  textColor?: string;
+};
+
+export const pillPropsToStyles = ({
+  color,
+  filled,
+  textColor,
+}: PillProps): string => {
+  const property = filled ? "background-color" : "border-color";
+  const textColorValue = textColor
+    ? `color: ${textColor}`
+    : `color: ${palette.text.caption}`;
+
+  return `
+    ${property}: ${color};
+    ${filled && !textColor ? `color: ${palette.white}` : textColorValue}
+  `;
+};
+
+export const Pill = styled.span<PillProps>`
+  align-items: center;
+  border-radius: ${rem(16)};
+  border: 1px solid transparent;
+  box-sizing: border-box;
+  display: inline-flex;
+  font-size: ${rem(14)};
+  height: ${rem(32)};
+  justify-content: center;
+  margin-right: ${rem(spacing.xs)};
+  padding: ${rem(spacing.xs)} ${rem(12)};
+  white-space: nowrap;
+
+  ${pillPropsToStyles}
+`;

--- a/packages/design-system/src/components/Pill/index.tsx
+++ b/packages/design-system/src/components/Pill/index.tsx
@@ -14,30 +14,5 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
-import Assets from "./assets";
 
-import polyfill from "./polyfill";
-
-export { Assets };
-
-polyfill();
-
-export * from "./styles";
-
-export * from "./components/Button";
-export * from "./components/Card";
-export * from "./components/ChartWrapper";
-export * from "./components/Dropdown";
-export * from "./components/ErrorPage";
-export * from "./components/GlobalStyle";
-export * from "./components/Header";
-export * from "./components/Icon";
-export * from "./components/Modal";
-export * from "./components/Need";
-export * from "./components/Search";
-export * from "./components/Tabs";
-export * from "./components/Toast";
-export * from "./components/Tooltip";
-export * from "./components/Typography";
-export * from "./components/Loading";
-export * from "./components/Pill";
+export * from "./Pill";


### PR DESCRIPTION
## Description of the change

This adopts the Pill component found in Case Triage with a few minor adjustments and should hopefully preclude further redundant implementations.

Here are the following props the Pill component accepts (* required):

- **color*** | sets color for `background-color` if `filled` is true, `border-color` if `filled` is false or is not explicitly defined
 
- **filled** | fills `background-color` when true. True if set explicitly or defined as a prop `<Pill filled={true}>` or `<Pill filled>`, false if set explicitly or undefined as a prop `<Pill filled={false}>` or `<Pill>`

- **textColor** | sets text `color`. If `textColor` is undefined as a prop and `filled` is true, it will default to a light text color. This can be overridden by setting textColor to a color value

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #67

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
