### PR TITLE
Add a DrawerModal Component

### DIFF
--- a/packages/design-system/src/components/Modal/DrawerModal.stories.tsx
+++ b/packages/design-system/src/components/Modal/DrawerModal.stories.tsx
@@ -1,0 +1,72 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import React from "react";
+import { Story, Meta } from "@storybook/react";
+import { DrawerModal as DrawerModalComponent } from "./DrawerModal";
+import { ModalProps } from "./Modal";
+
+export default {
+  title: "Design System/Components/DrawerModal",
+  component: DrawerModalComponent,
+  parameters: {
+    controls: {
+      include: ["width", "isOpen"],
+    },
+    docs: {
+      // Render modal inside an iframe so that `position: fixed`; is contained
+      inlineStories: false,
+      iframeHeight: "300px",
+    },
+  },
+  argTypes: {
+    isOpen: {
+      description: "Toggles modal open/close",
+      type: "boolean",
+    },
+    width: {
+      description:
+        "Sets the `width` of the modal. If not explicitly set, it defaults to a (responsive) width of `555`px",
+      type: "number",
+    },
+  },
+} as Meta;
+
+const Template: Story<ModalProps & { width?: number }> = ({
+  width,
+  isOpen,
+}) => {
+  return (
+    <DrawerModalComponent width={width} isOpen={isOpen}>
+      Hello, this is a blank and unpadded Drawer Modal...
+      <h3 style={{ padding: 20 }}>
+        ...where you can add your own custom-styled components.
+      </h3>
+    </DrawerModalComponent>
+  );
+};
+
+export const DrawerModal: Story<
+  ModalProps & { width?: number }
+> = Template.bind({});
+
+DrawerModal.args = {
+  width: 300,
+  isOpen: true,
+};
+
+DrawerModal.storyName = "DrawerModal";

--- a/packages/design-system/src/components/Modal/DrawerModal.tsx
+++ b/packages/design-system/src/components/Modal/DrawerModal.tsx
@@ -1,0 +1,78 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2021 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import { rem } from "polished";
+import styled from "styled-components";
+import { Card } from "../Card";
+import { Modal } from ".";
+
+const UnpaddedModal = styled(Modal)`
+  /* need extra specificity to override base */
+  && .ReactModal__Content {
+    padding: 0;
+  }
+
+  ${Card} {
+    box-shadow: none;
+  }
+`;
+
+const DEFAULT_DRAWER_MARGIN = 24;
+const DEFAULT_DRAWER_WIDTH = 555;
+
+/**
+ * This component inherits from the **Modal** component
+ * which itself is a wrapper around the
+ * [React Modal]({https://www.npmjs.com/package/react-modal) package.
+ *
+ * It will dim and blur the page behind it while open, and prevent the page from scrolling
+ * using the [Body Scroll Lock](https://www.npmjs.com/package/body-scroll-lock) package.
+ *
+ * The `width` can be adjusted manually by providing a `number`. If not set explicitly, it
+ * will default to a (responsive) width of `555`px.
+ *
+ * The `isOpen` prop controls modal visibility, and the `onRequestClose`
+ * prop is a hook that should set `isOpen` to `false`.
+ */
+export const DrawerModal = styled(UnpaddedModal)<{ width?: number }>`
+  /* need extra specificity to override base */
+  && .ReactModal__Content {
+    height: calc(100vh - ${rem(DEFAULT_DRAWER_MARGIN * 2)});
+    max-height: unset;
+    max-width: calc(100vw - ${rem(DEFAULT_DRAWER_MARGIN * 2)});
+    width: ${(props) => rem(props.width || DEFAULT_DRAWER_WIDTH)};
+
+    /* transition: slide out from side instead of zooming from center */
+    left: unset;
+    right: ${rem(DEFAULT_DRAWER_MARGIN)};
+    transform: translate(
+      ${(props) => rem(props.width || DEFAULT_DRAWER_WIDTH)},
+      -50%
+    ) !important;
+
+    &.ReactModal__Content--after-open {
+      transform: translate(0, -50%) !important;
+    }
+
+    &.ReactModal__Content--before-close {
+      transform: translate(
+        ${(props) => rem(props.width || DEFAULT_DRAWER_WIDTH)},
+        -50%
+      ) !important;
+    }
+  }
+`;

--- a/packages/design-system/src/components/Modal/index.ts
+++ b/packages/design-system/src/components/Modal/index.ts
@@ -14,4 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
+
 export * from "./Modal";
+export * from "./DrawerModal";


### PR DESCRIPTION
## Description of the change

This adopts the DrawerModal component found in Case Triage with a customizable `width` property that should hopefully preclude further redundant implementations.

- **width** | can be adjusted manually by providing a `number`. If not set explicitly, it will default to a (responsive) width of `555`px.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #69

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
