### PR TITLE
Add `iconToDataURI` helper

### DIFF
--- a/packages/design-system/CHANGELOG.md
+++ b/packages/design-system/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v3.2.0
+
+### Added
+
+- `iconToDataURI` helper which converts `<Icon/>`s into data URIs for use in background images.
+
+```tsx
+iconToDataURI(<Icon kind={IconSVG.Edit} fill={palette.slate} />)
+```
+
 ## v3.1.0
 
 ### Added

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recidiviz/design-system",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "UI components and styles for Recidiviz web products.",
   "author": "Recidiviz <team@recidiviz.org>",
   "license": "GPL-3.0-only",

--- a/packages/design-system/src/components/Icon/Icon.stories.tsx
+++ b/packages/design-system/src/components/Icon/Icon.stories.tsx
@@ -16,7 +16,8 @@
 // =============================================================================
 import * as React from "react";
 import { Story, Meta } from "@storybook/react";
-import { Icon as IconComponent, IconProps } from "./Icon";
+import styled from "styled-components";
+import { Icon as IconComponent, IconProps, iconToDataURI } from "./Icon";
 import { IconSVG } from "./IconSVG";
 import { palette } from "../../styles";
 
@@ -26,6 +27,7 @@ export default {
   argTypes: {
     color: {
       control: "color",
+      defaultValue: palette.signal.highlight,
     },
     kind: {
       control: {
@@ -48,8 +50,35 @@ export default {
   },
 } as Meta;
 
+const IconButton = styled.button.attrs({ type: "button" })`
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 80% 80%;
+  border-radius: 4px;
+  color: ${palette.pine1};
+  text-shadow: -1px 1px white;
+  font-size: 1.2em;
+  font-weight: bold;
+  display: block;
+  height: 72px;
+  width: 72px;
+`;
+
 const Template: Story<IconProps> = ({ kind, color, height, width }) => (
-  <IconComponent kind={kind} color={color} height={height} width={width} />
+  <>
+    <IconComponent kind={kind} color={color} height={height} width={width} />
+    <hr />
+    Icons can also be used as background images:
+    <IconButton
+      style={{
+        backgroundImage: iconToDataURI(
+          <IconComponent kind={kind} fill={color} />
+        ),
+      }}
+    >
+      Press me!
+    </IconButton>
+  </>
 );
 
 export const Icon = Template.bind({});

--- a/packages/design-system/src/components/Icon/Icon.tsx
+++ b/packages/design-system/src/components/Icon/Icon.tsx
@@ -16,6 +16,7 @@
 // =============================================================================
 
 import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { ExternalPropsContext, IconSVGProps, IconSVG } from "./IconSVG";
 
 export interface IconProps extends IconSVGProps {
@@ -68,3 +69,8 @@ export const Icon: React.FC<IconProps> = ({
     </ExternalPropsContext.Provider>
   );
 };
+
+export const iconToDataURI = (template: JSX.Element): string =>
+  `url("data:image/svg+xml,${encodeURIComponent(
+    renderToStaticMarkup(template)
+  )}")`;


### PR DESCRIPTION
## Description of the change

Adds a helper for converting icons to data URIs and bumps `design-system` to `3.2.0`

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues


## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
