### PR TITLE
[design-system] Add ability to accept and forward ref within ChartWrapper component

### DIFF
--- a/packages/design-system/CHANGELOG.md
+++ b/packages/design-system/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- ChartWrapper now has the ability to forward a `ref`.
+- ChartWrapper accepts and forwards a `ref`.
 
 ```tsx
 <ChartWrapper className={className} ref={ref}>

--- a/packages/design-system/CHANGELOG.md
+++ b/packages/design-system/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v3.3.0
+
+### Added
+
+- ChartWrapper now has the ability to forward a `ref`.
+
+```tsx
+<ChartWrapper className={className} ref={ref}>
+  ...
+</ChartWrapper>
+```
+
 ## v3.2.0
 
 ### Added

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recidiviz/design-system",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "UI components and styles for Recidiviz web products.",
   "author": "Recidiviz <team@recidiviz.org>",
   "license": "GPL-3.0-only",

--- a/packages/design-system/src/components/ChartWrapper/ChartWrapper.tsx
+++ b/packages/design-system/src/components/ChartWrapper/ChartWrapper.tsx
@@ -94,11 +94,6 @@ const SemioticWrapper = styled.div`
 
 export type ChartWrapperProps = {
   className?: string;
-  ref?:
-    | ((instance: HTMLDivElement | null) => void)
-    | React.RefObject<HTMLDivElement>
-    | null
-    | undefined;
 };
 
 /**
@@ -106,7 +101,7 @@ export type ChartWrapperProps = {
  * Recidiviz baseline styles to classes rendered by Semiotic.
  */
 
-export const ChartWrapper: React.FC<ChartWrapperProps> = React.forwardRef(
+export const ChartWrapper = React.forwardRef<HTMLDivElement, ChartWrapperProps>(
   ({ className, children }, ref) => {
     return (
       <SemioticWrapper className={className} ref={ref}>

--- a/packages/design-system/src/components/ChartWrapper/ChartWrapper.tsx
+++ b/packages/design-system/src/components/ChartWrapper/ChartWrapper.tsx
@@ -94,15 +94,24 @@ const SemioticWrapper = styled.div`
 
 export type ChartWrapperProps = {
   className?: string;
+  ref?:
+    | ((instance: HTMLDivElement | null) => void)
+    | React.RefObject<HTMLDivElement>
+    | null
+    | undefined;
 };
 
 /**
  * Wrapper component for Semiotic chart components that applies
  * Recidiviz baseline styles to classes rendered by Semiotic.
  */
-export const ChartWrapper: React.FC<ChartWrapperProps> = ({
-  className,
-  children,
-}) => {
-  return <SemioticWrapper className={className}>{children}</SemioticWrapper>;
-};
+
+export const ChartWrapper: React.FC<ChartWrapperProps> = React.forwardRef(
+  ({ className, children }, ref) => {
+    return (
+      <SemioticWrapper className={className} ref={ref}>
+        {children}
+      </SemioticWrapper>
+    );
+  }
+);


### PR DESCRIPTION
## Description of the change

Adds ability to accept and forward a `ref` within the ChartWrapper component.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes #93

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
