### PR TITLE
[design-system] Fix TypeScript error within `ChartWrapper` when adding `children`

### DIFF
--- a/packages/design-system/CHANGELOG.md
+++ b/packages/design-system/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## v3.3.1
+
+### Fixed
+
+- Fixes TypeScript error within `ChartWrapper` when adding `children`.
 
 ## v3.3.0
 

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recidiviz/design-system",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "UI components and styles for Recidiviz web products.",
   "author": "Recidiviz <team@recidiviz.org>",
   "license": "GPL-3.0-only",

--- a/packages/design-system/src/components/ChartWrapper/ChartWrapper.tsx
+++ b/packages/design-system/src/components/ChartWrapper/ChartWrapper.tsx
@@ -101,12 +101,13 @@ export type ChartWrapperProps = {
  * Recidiviz baseline styles to classes rendered by Semiotic.
  */
 
-export const ChartWrapper = React.forwardRef<HTMLDivElement, ChartWrapperProps>(
-  ({ className, children }, ref) => {
-    return (
-      <SemioticWrapper className={className} ref={ref}>
-        {children}
-      </SemioticWrapper>
-    );
-  }
-);
+export const ChartWrapper = React.forwardRef<
+  HTMLDivElement,
+  React.PropsWithChildren<ChartWrapperProps>
+>(({ className, children }, ref) => {
+  return (
+    <SemioticWrapper className={className} ref={ref}>
+      {children}
+    </SemioticWrapper>
+  );
+});


### PR DESCRIPTION
## Description of the change

Resolves the below TypeScript error when adding `children` to ChartWrapper component:

`No overload matches this call. Overload 1 of 2, '(props: Omit<Omit<ChartWrapperProps & RefAttributes<HTMLDivElement>, never> & Partial<Pick<ChartWrapperProps & RefAttributes<...>, never>>, "theme"> & { ...; } & { ...; }): ReactElement<...>', gave the following error. Type '{ children: Element; }' has no properties in common with type 'IntrinsicAttributes & Omit<Omit<ChartWrapperProps & RefAttributes<HTMLDivElement>, never> & Partial<...>, "theme"> & { ...; } & { ...; }'. Overload 2 of 2, '(props: StyledComponentPropsWithAs<ForwardRefExoticComponent<ChartWrapperProps & RefAttributes<HTMLDivElement>>, any, {}, never>): ReactElement<...>', gave the following error. Type '{ children: Element; }' has no properties in common with type 'IntrinsicAttributes & Omit<Omit<ChartWrapperProps & RefAttributes<HTMLDivElement>, never> & Partial<...>, "theme"> & { ...; } & { ...; }'.`

`React.forwardRef` is a `React.ForwardRefExoticComponent` and not a `React.FC` - therefore, the typing of `children` is not explicitly defined in `ForwardRefExoticComponent`. Adding `React.PropsWithChildren<ChartWrapperProps>` provides it with the proper typing of `children`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Contributes to #93 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
