### PR TITLE
Upgrade to Node 16

### DIFF
--- a/packages/tsconfig/e2e.json
+++ b/packages/tsconfig/e2e.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node12/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "types": [
       "node",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recidiviz/tsconfig",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Typescript config bases for Recidiviz web applications",
   "author": "Recidiviz <team@recidiviz.org>",
   "files": [
@@ -9,9 +9,9 @@
   ],
   "license": "GPL-3.0-only",
   "engines": {
-    "node": ">=12.x.x"
+    "node": ">=16.x.x"
   },
   "dependencies": {
-    "@tsconfig/node12": "^1.0.7"
+    "@tsconfig/node16": "^1.0.2"
   }
 }

--- a/packages/tsconfig/yarn.lock
+++ b/packages/tsconfig/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@tsconfig/node12@^1.0.7":
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.7.tgz#677bd9117e8164dc319987dd6ff5fc1ba6fbf18b"
-  integrity sha512-dgasobK/Y0wVMswcipr3k0HpevxFJLijN03A8mYfEPvWvOs14v0ZlYTR4kIgMx8g4+fTyTFv8/jLCIfRqLDJ4A==
+"@tsconfig/node16@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
+  integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==


### PR DESCRIPTION
## Description of the change

This upgrades the `tsconfig` package to version 2.0.0, which upgrades from Node 12 to Node 16. Once merged, I will publish the new package version.

This has been tested alongside the `pulse-dashboard` Node upgrade.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Part of [#1924](https://app.zenhub.com/workspaces/polaris-614c9f27fa19b10015ddd495/issues/recidiviz/pulse-dashboard/1924)

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
