### PR TITLE
[design system] update dev-link for better CRA compatibility

### DIFF
--- a/packages/design-system/README.md
+++ b/packages/design-system/README.md
@@ -16,7 +16,7 @@ Use the `yarn dev` will run Storybook. Source files will be watched and automati
 
 The component library can be developed directly alongside dependent projects. The easiest way to do this is with [yalc](https://github.com/wclr/yalc) (which you should probably install globally).
 
-Running `yarn watch` will rebuild the application bundle and publish it to yalc whenever you make changes. In the dependent project(s), there is a one-time step of running `yalc add @recidiviz/design-system` (and `yarn install`) before starting the development server for that application; once this is done, your changes here should be picked up automatically and trigger a reload. Run `yalc remove @recidiviz/design-system` to restore the project's dependencies to their previous state.
+Running `yarn watch` will rebuild the application bundle and publish it to yalc whenever you make changes. In the dependent project(s), there is a one-time step of running `yalc add --link @recidiviz/design-system` (and `yarn install`) before starting the development server for that application; once this is done, your changes here should be picked up automatically and trigger a reload. Run `yalc remove @recidiviz/design-system` to restore the project's dependencies to their previous state.
 
 The scripts `yarn dev-link` and `yarn dev-unlink` will do this for you, e.g., `yarn dev-link ~/path/to/project`
 

--- a/packages/design-system/scripts/dev-link.sh
+++ b/packages/design-system/scripts/dev-link.sh
@@ -7,5 +7,5 @@ else
   exit 1
 fi
 cd $1
-yalc add @recidiviz/design-system
+yalc add --link @recidiviz/design-system
 yarn


### PR DESCRIPTION
## Description of the change

After pursuing a variety of dead ends to try to improve the developer experience of using `yarn watch` to develop alongside one of our applications, I found that this simple change in how one uses `yalc` actually works pretty consistently across both Spotlight and Pulse Dashboard; in my experience connecting the two local packages this way caused the applications to consistently hot-reload on Design System changes with `yarn watch` running. I will not pretend to understand why! I just know that using `yalc add` without the `--link` option does not trigger reloading, and using `yalc link` just doesn't work at all, but `yalc add --link` is the right combination of magical nonsense words. 🧙🏻 

(Now that the version of Node is not locked to 12.x in Pulse Dashboard you can actually use this script for that repo also! But you can also always just run the  same `yalc` command manually in whatever package you are trying to link to this one) 

## Type of change

- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> n/a

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
