### PR TITLE
[design-system] Add logic to prevent dropdown from closing when item is selected if indicated

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recidiviz/design-system",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "UI components and styles for Recidiviz web products.",
   "author": "Recidiviz <team@recidiviz.org>",
   "license": "GPL-3.0-only",

--- a/packages/design-system/src/components/Dropdown/DropdownMenu.tsx
+++ b/packages/design-system/src/components/Dropdown/DropdownMenu.tsx
@@ -60,8 +60,13 @@ export const DropdownMenu = ({
   React.useEffect(() => {
     const handleFocus = (event: FocusEvent) => {
       const target = event.target as HTMLElement;
-
-      if (!focusManager.dropdown?.current?.contains(target)) {
+      if (
+        !focusManager.dropdown?.current?.contains(target) &&
+        // Do not close the dropdown if the event target is modal content,
+        // otherwise dropdowns inside of modals are broken.
+        // This allows the event to propagate down to the correct input component.
+        !target.className.includes("ReactModal__Content")
+      ) {
         setShown(false);
       }
     };

--- a/packages/design-system/src/components/Dropdown/DropdownMenu.tsx
+++ b/packages/design-system/src/components/Dropdown/DropdownMenu.tsx
@@ -60,13 +60,8 @@ export const DropdownMenu = ({
   React.useEffect(() => {
     const handleFocus = (event: FocusEvent) => {
       const target = event.target as HTMLElement;
-      if (
-        !focusManager.dropdown?.current?.contains(target) &&
-        // Do not close the dropdown if the event target is modal content,
-        // otherwise dropdowns inside of modals are broken.
-        // This allows the event to propagate down to the correct input component.
-        !target.className.includes("ReactModal__Content")
-      ) {
+
+      if (!focusManager.dropdown?.current?.contains(target)) {
         setShown(false);
       }
     };

--- a/packages/design-system/src/components/Dropdown/DropdownMenuItem.tsx
+++ b/packages/design-system/src/components/Dropdown/DropdownMenuItem.tsx
@@ -19,8 +19,6 @@ import * as React from "react";
 import { MenuItemElement } from "./Dropdown.styles";
 import DropdownContext from "./DropdownContext";
 
-export const DROPDOWN_PREVENT_DEFAULT = 1;
-
 export interface DropdownMenuItemProps {
   className?: string;
   /**
@@ -29,6 +27,7 @@ export interface DropdownMenuItemProps {
   label?: string;
   children?: React.ReactNode;
   onClick: React.MouseEventHandler<HTMLButtonElement>;
+  preventCloseOnClickEvent?: boolean;
 }
 
 export const DropdownMenuItem = ({
@@ -36,6 +35,7 @@ export const DropdownMenuItem = ({
   label,
   children,
   onClick,
+  preventCloseOnClickEvent,
 }: DropdownMenuItemProps): JSX.Element => {
   const { focusManager, shown, setShown } = useContext(DropdownContext);
   const ref = useRef<HTMLButtonElement>(null);
@@ -59,10 +59,8 @@ export const DropdownMenuItem = ({
       }
       onMouseEnter={onMouseEnter}
       onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
-        // To prevent closing of the dropdown when selecting an item, return DROPDOWN_PREVENT_DEFAULT from the onClick of the item
-        const preventClose =
-          (onClick(event) as void | number) === DROPDOWN_PREVENT_DEFAULT;
-        if (!preventClose) {
+        onClick(event);
+        if (!preventCloseOnClickEvent) {
           setShown(false);
           focusManager.focusToggle();
         }

--- a/packages/design-system/src/components/Dropdown/DropdownMenuItem.tsx
+++ b/packages/design-system/src/components/Dropdown/DropdownMenuItem.tsx
@@ -19,6 +19,8 @@ import * as React from "react";
 import { MenuItemElement } from "./Dropdown.styles";
 import DropdownContext from "./DropdownContext";
 
+export const DROPDOWN_PREVENT_DEFAULT = 1;
+
 export interface DropdownMenuItemProps {
   className?: string;
   /**
@@ -57,9 +59,13 @@ export const DropdownMenuItem = ({
       }
       onMouseEnter={onMouseEnter}
       onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
-        onClick(event);
-        setShown(false);
-        focusManager.focusToggle();
+        // To prevent closing of the dropdown when selecting an item, return DROPDOWN_PREVENT_DEFAULT from the onClick of the item
+        const preventClose =
+          (onClick(event) as void | number) === DROPDOWN_PREVENT_DEFAULT;
+        if (!preventClose) {
+          setShown(false);
+          focusManager.focusToggle();
+        }
       }}
       disabled={!shown}
       tabIndex={-1}


### PR DESCRIPTION
## Description of the change

Adds logic to prevent closing the `DropdownMenu` when the event target is modal content, otherwise a dropdown inside of modals are broken because the menu is closed before the input has a chance to call its `onChange` handler.

This is admittedly pretty hacky, I'm open to other ideas about how to resolve this issue. I have played around with the z-indexes of the modal/modal content/dropdown, but the click event target remains the modal content.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes [#XXXX]

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
