### PR TITLE
[design-system] Move tooltip to the left if it lacks space from the right

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recidiviz/design-system",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "UI components and styles for Recidiviz web products.",
   "author": "Recidiviz <team@recidiviz.org>",
   "license": "GPL-3.0-only",

--- a/packages/design-system/src/components/Tooltip/TooltipTrigger.tsx
+++ b/packages/design-system/src/components/Tooltip/TooltipTrigger.tsx
@@ -65,6 +65,7 @@ export const TooltipTrigger: React.FC<TooltipTriggerProps> = ({
   const [offset, setOffset] = React.useState({ top: "0px", left: "0px" });
   // Event handlers should not be
   const [showTooltip, setShowTooltip] = useTooltipState(contents);
+  const tooltipRef = React.useRef<HTMLDivElement>(null);
 
   const transitions = useTransition(showTooltip, {
     from: { opacity: 0 },
@@ -87,13 +88,22 @@ export const TooltipTrigger: React.FC<TooltipTriggerProps> = ({
     }
 
     let offsetLeft = x;
-    // if tooltip doesn't have enough space on the right move it to the left relative to pointer. Works only when maxWidth is specified
+    let offsetWidth = 0;
+
+    if (tooltipRef.current) {
+      offsetWidth = tooltipRef.current.offsetWidth;
+
+      if (maxWidth) offsetWidth = maxWidth;
+      if (offsetWidth > 300) offsetWidth = 300;
+    }
+
+    // if tooltip doesn't have enough space on the right move it to the left relative to pointer.
     if (
-      maxWidth &&
-      window.innerWidth - x < maxWidth &&
-      x - maxWidth > pointerOffset
+      offsetWidth &&
+      window.innerWidth - x < offsetWidth &&
+      x - offsetWidth > pointerOffset
     ) {
-      offsetLeft = x - maxWidth - (pointerOffset + 5);
+      offsetLeft = x - offsetWidth - (pointerOffset + 5);
     }
 
     frame = window.requestAnimationFrame(() => {
@@ -135,6 +145,7 @@ export const TooltipTrigger: React.FC<TooltipTriggerProps> = ({
           (styles, item) =>
             item && (
               <AnimatedTooltip
+                ref={tooltipRef}
                 maxWidth={maxWidth}
                 style={{ ...styles, top: offset.top, left: offset.left }}
               >

--- a/packages/design-system/src/components/Tooltip/TooltipTrigger.tsx
+++ b/packages/design-system/src/components/Tooltip/TooltipTrigger.tsx
@@ -80,20 +80,35 @@ export const TooltipTrigger: React.FC<TooltipTriggerProps> = ({
   });
 
   let frame: number;
+  const pointerOffset = 15;
   const updateTooltipPosition = (x: number, y: number) => {
     if (typeof frame !== "undefined") {
       window.cancelAnimationFrame(frame);
     }
+
+    let offsetLeft = x;
+    // if tooltip doesn't have enough space on the right move it to the left relative to pointer. Works only when maxWidth is specified
+    if (
+      maxWidth &&
+      window.innerWidth - x < maxWidth &&
+      x - maxWidth > pointerOffset
+    ) {
+      offsetLeft = x - maxWidth - (pointerOffset + 5);
+    }
+
     frame = window.requestAnimationFrame(() => {
       setOffset({
-        left: `${x}px`,
+        left: `${offsetLeft}px`,
         top: `${y}px`,
       });
     });
   };
 
   const onMouseMove: React.MouseEventHandler<HTMLDivElement> = (event) => {
-    updateTooltipPosition(event.clientX + 15, event.clientY + 15);
+    updateTooltipPosition(
+      event.clientX + pointerOffset,
+      event.clientY + pointerOffset
+    );
   };
 
   const onMouseEnter = () => {
@@ -108,7 +123,7 @@ export const TooltipTrigger: React.FC<TooltipTriggerProps> = ({
     // if someone clicked on a hovered item don't override mouse position
     if (!showTooltip) {
       const bounds = event.target.getBoundingClientRect();
-      updateTooltipPosition(bounds.right + 15, bounds.top);
+      updateTooltipPosition(bounds.right + pointerOffset, bounds.top);
     }
     setShowTooltip(true);
   };


### PR DESCRIPTION
## Description of the change

If tooltip doesn't have enough space on the right move it to the left relative to pointer. Works only when maxWidth is specified.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes [#XXXX]

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
