### PR TITLE
Require nodes as AuthWall props instead of component functions

### DIFF
--- a/packages/auth/.eslintrc.js
+++ b/packages/auth/.eslintrc.js
@@ -1,3 +1,20 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2023 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
 module.exports = {
   extends: ["@recidiviz"],
   plugins: ["header"],
@@ -15,5 +32,5 @@ module.exports = {
         ],
       },
     ],
-  }
+  },
 };

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -40,9 +40,9 @@ Initialize the AuthStore by providing it with `{ authSettings }` (see [Auth0Clie
 ```
 <AuthWall 
   authStore
-  Loading
-  UnauthorizedPage
-  EmailVerificationPage
+  loading
+  unauthorizedPage
+  emailVerificationPage
   handleTargetUrl
 >
   <ProtectedComponent />
@@ -52,9 +52,9 @@ Initialize the AuthStore by providing it with `{ authSettings }` (see [Auth0Clie
 | Required Props | Description |
 | -: | - |
 | authStore | initialized AuthStore |
-| Loading | component that renders the loading page/state |
-| UnauthorizedPage | component that renders the page for an unauthorized user logging in |
-| EmailVerificationPage | component that renders the page for a user who has not verified their email address |
+| loading | contents to render for loading page/state |
+| unauthorizedPage | contents to render for an unauthorized user logging in |
+| emailVerificationPage | contents to render for a user who has not verified their email address |
 
 <br />
 

--- a/packages/auth/license-header.js
+++ b/packages/auth/license-header.js
@@ -1,5 +1,5 @@
 // Recidiviz - a data platform for criminal justice reform
-// Copyright (C) 2022 Recidiviz, Inc.
+// Copyright (C) 2023 Recidiviz, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/packages/auth/src/Auth.test.tsx
+++ b/packages/auth/src/Auth.test.tsx
@@ -1,5 +1,5 @@
 // Recidiviz - a data platform for criminal justice reform
-// Copyright (C) 2022 Recidiviz, Inc.
+// Copyright (C) 2023 Recidiviz, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/packages/auth/src/AuthStore.ts
+++ b/packages/auth/src/AuthStore.ts
@@ -1,5 +1,5 @@
 // Recidiviz - a data platform for criminal justice reform
-// Copyright (C) 2022 Recidiviz, Inc.
+// Copyright (C) 2023 Recidiviz, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/packages/auth/src/AuthStore.ts
+++ b/packages/auth/src/AuthStore.ts
@@ -131,9 +131,7 @@ export class AuthStore {
     return this.authClient?.logout({ returnTo: window.location.origin });
   }
 
-  async getTokenSilently(
-    options?: GetTokenSilentlyOptions
-  ): Promise<string | Error> {
+  async getTokenSilently(options?: GetTokenSilentlyOptions): Promise<string> {
     if (this.authClient) {
       try {
         return this.authClient.getTokenSilently(options);

--- a/packages/auth/src/AuthWall.tsx
+++ b/packages/auth/src/AuthWall.tsx
@@ -1,5 +1,5 @@
 // Recidiviz - a data platform for criminal justice reform
-// Copyright (C) 2022 Recidiviz, Inc.
+// Copyright (C) 2023 Recidiviz, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/packages/auth/src/AuthWall.tsx
+++ b/packages/auth/src/AuthWall.tsx
@@ -17,24 +17,24 @@
 
 import { when } from "mobx";
 import { observer } from "mobx-react-lite";
-import React, { useEffect } from "react";
+import React, { ReactNode, useEffect } from "react";
 
 import { AuthStore } from "./AuthStore";
 
 type AuthWallProps = {
   authStore: AuthStore;
-  Loading: () => JSX.Element;
-  UnauthorizedPage: () => JSX.Element;
-  EmailVerificationPage: () => JSX.Element;
+  loading: ReactNode;
+  unauthorizedPage: ReactNode;
+  emailVerificationPage: ReactNode;
   handleTargetUrl?: (targetUrl: string) => void;
-  children: React.ReactNode;
+  children: ReactNode;
 };
 
 const AuthWall: React.FC<AuthWallProps> = ({
   authStore,
-  Loading,
-  UnauthorizedPage,
-  EmailVerificationPage,
+  loading,
+  unauthorizedPage,
+  emailVerificationPage,
   handleTargetUrl,
   children,
 }): React.ReactElement | null => {
@@ -50,15 +50,15 @@ const AuthWall: React.FC<AuthWallProps> = ({
   );
 
   if (authStore.isLoading) {
-    return <Loading />;
+    return <>{loading}</>;
   }
 
   if (!authStore.isAuthorized) {
-    return <UnauthorizedPage />;
+    return <>{unauthorizedPage}</>;
   }
 
   if (!authStore.emailVerified) {
-    return <EmailVerificationPage />;
+    return <>{emailVerificationPage}</>;
   }
 
   return authStore.isAuthorized ? <>{children}</> : null;

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,5 +1,5 @@
 // Recidiviz - a data platform for criminal justice reform
-// Copyright (C) 2022 Recidiviz, Inc.
+// Copyright (C) 2023 Recidiviz, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
## Description of the change

I think this makes the component interface more flexible (e.g. consumers may wish to provide their own props to the components that may be rendered) and the type definitions a bit cleaner. I have a reference implementation that uses this interface in [this PR](https://github.com/Recidiviz/recidiviz-data/pull/17974). That would be the first live use case for this library! We will have to publish it after this is merged (it hasn't been published yet so I didn't see any reason to bump the version)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

n/a

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
