### PR TITLE
[Auth] Separate auth check from login redirect

### DIFF
--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -13,27 +13,9 @@ This module contains two components:
 
 **AuthStore**
 
-Initialize the AuthStore by providing it with `{ authSettings }` (see [Auth0ClientOptions](https://auth0.github.io/auth0-spa-js/interfaces/auth0clientoptions.html)):
+Initialize the AuthStore by providing it with `{ authSettings }` (see [Auth0ClientOptions](https://auth0.github.io/auth0-spa-js/interfaces/Auth0ClientOptions.html)):
 
 `const authStore = new AuthStore({ authSettings });`
-
-| Functions | Description |
-| -: | - |
-| auth0Client | asynchronously creates the Auth0Client instance |
-| authenticate | initializes Auth0Client, handles redirect, sets the user object and authentication state  |
-| logout | clears the Auth0 session and performs a redirect to  `/v2/logout` |
-| getTokenSilently | calls Auth0's [getTokenSilently](https://auth0.github.io/auth0-spa-js/classes/auth0client.html#gettokensilently) function to fetch a new access token with no interaction |
-
-<br />
-
-| &nbsp; &nbsp;  &nbsp;  &nbsp;  &nbsp; Properties | Description |
-| -: | - |
-| emailVerified | indicates whether the user has verified their email address |
-| isAuthorized | indicates whether the user has successfully authenticated |
-| isLoading | indicates whether there is an active loading state |
-| error | stores active error |
-| user | stores information about the logged-in user |
-
 
 **AuthWall**
 

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recidiviz/auth",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Auth0-Powered Authentication Module",
   "author": "Recidiviz <team@recidiviz.org>",
   "license": "GPL-3.0-only",

--- a/packages/auth/src/AuthStore.ts
+++ b/packages/auth/src/AuthStore.ts
@@ -37,14 +37,29 @@ export class AuthStore {
 
   private authClient: Auth0Client | undefined;
 
+  /**
+   * indicates whether the user has verified their email address
+   */
   emailVerified?: boolean;
 
+  /**
+   * indicates whether the user has successfully authenticated
+   */
   isAuthorized: boolean;
 
+  /**
+   * indicates whether there is an active loading state (an auth check is still pending)
+   */
   isLoading: boolean;
 
+  /**
+   * Error(s) occurring during auth
+   */
   error: Error | Record<string, unknown>;
 
+  /**
+   * stores information about the logged-in user
+   */
   user?: User;
 
   constructor({ authSettings }: AuthStoreProps) {
@@ -57,6 +72,11 @@ export class AuthStore {
     this.error = {};
   }
 
+  /**
+   * Asynchronously creates the Auth0Client instance and returns it.
+   * If a client is already stored on this instance it will return that
+   * rather than creating a new one.
+   */
   private async getAuth0Client(): Promise<Auth0Client> {
     if (!this.authSettings) {
       runInAction(() => {
@@ -138,6 +158,9 @@ export class AuthStore {
     return this.isAuthorized;
   }
 
+  /**
+   * Redirects to the Auth0 login flow
+   */
   async loginWithRedirect(): Promise<void> {
     const client = await this.getAuth0Client();
 
@@ -158,6 +181,9 @@ export class AuthStore {
     }
   }
 
+  /**
+   * clears the Auth0 session and performs a redirect to  `/v2/logout`
+   */
   async logout(): Promise<void> {
     runInAction(() => {
       this.isAuthorized = false;
@@ -167,6 +193,9 @@ export class AuthStore {
     return this.authClient?.logout({ returnTo: window.location.origin });
   }
 
+  /**
+   * Gets an Auth0 access token silently, if allowed. Throws otherwise
+   */
   async getTokenSilently(options?: GetTokenSilentlyOptions): Promise<string> {
     if (this.authClient) {
       try {


### PR DESCRIPTION
## Description of the change

To support a pre-login landing page in the JII app we need to be able to check authentication status without immediately redirecting logged-out users to the login flow, and then redirect them later in response to user input. This refactors the existing functionality to allow that, while preserving the behavior of `AuthStore.authenticate()` for backwards compatibility.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

https://github.com/Recidiviz/recidiviz-dashboards/issues/5410

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
