### PR TITLE
[Design System] Enable contentRef prop in Modal

### DIFF
--- a/packages/design-system/CHANGELOG.md
+++ b/packages/design-system/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v5.3.0
+## v5.4.0
 
 ### Added
 

--- a/packages/design-system/CHANGELOG.md
+++ b/packages/design-system/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- Support for `contentRef` prop on `Modal`
+
+## v5.3.0
+
+### Added
+
 - `ArrowCircled` SVG icon (#179)
 
 ## v5.2.0

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recidiviz/design-system",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "UI components and styles for Recidiviz web products.",
   "author": "Recidiviz <team@recidiviz.org>",
   "license": "GPL-3.0-only",

--- a/packages/design-system/src/components/Modal/Modal.tsx
+++ b/packages/design-system/src/components/Modal/Modal.tsx
@@ -26,7 +26,7 @@ import { animation, palette, typography, zindex } from "../../styles";
 ReactModal.defaultStyles.content = {};
 ReactModal.defaultStyles.overlay = {};
 
-export interface ModalProps extends Omit<ReactModal.Props, "contentRef"> {
+export interface ModalProps extends ReactModal.Props {
   className?: string;
 }
 
@@ -40,6 +40,7 @@ const UnstyledModal: React.FC<ModalProps> = ({
   className,
   onAfterOpen,
   onAfterClose,
+  contentRef,
   ...rest
 }) => {
   const modalContentRef = React.useRef<HTMLDivElement | null>(null);
@@ -49,6 +50,7 @@ const UnstyledModal: React.FC<ModalProps> = ({
       closeTimeoutMS={300}
       {...rest}
       contentRef={(node) => {
+        if (contentRef) contentRef(node);
         if (node) modalContentRef.current = node;
       }}
       onAfterClose={() => {


### PR DESCRIPTION
## Description of the change

(PR authored by @matankb, I just had to make another PR to get the actions to run.)
This PR changes the Modal component to forwards the `contentRef` prop to the internal react-modal component.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes [#XXXX]

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
