### PR TITLE
(opened new PR)

### DIFF
--- a/packages/design-system/CHANGELOG.md
+++ b/packages/design-system/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v5.5.0
+
+### Added
+
+- Support for `positionX` and `positionY` prop on `TooltipTrigger`
+
 ## v5.4.0
 
 ### Added

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recidiviz/design-system",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "description": "UI components and styles for Recidiviz web products.",
   "author": "Recidiviz <team@recidiviz.org>",
   "license": "GPL-3.0-only",

--- a/packages/design-system/src/components/Tooltip/TooltipTrigger.tsx
+++ b/packages/design-system/src/components/Tooltip/TooltipTrigger.tsx
@@ -27,6 +27,11 @@ type TooltipTriggerProps = {
   contents: React.ReactNode;
   maxWidth?: number;
   backgroundColor?: string;
+
+  // if positionX or positionY are provided, it will
+  // override the autopositioning for that axis
+  positionX?: "right" | "left";
+  positionY?: "top" | "bottom";
 };
 
 const AnimatedTooltip = animated(Tooltip);
@@ -63,6 +68,8 @@ export const TooltipTrigger: React.FC<TooltipTriggerProps> = ({
   contents,
   maxWidth,
   backgroundColor,
+  positionX,
+  positionY,
 }: TooltipTriggerProps) => {
   const [offset, setOffset] = React.useState({ top: "0px", left: "0px" });
   // Event handlers should not be
@@ -106,13 +113,17 @@ export const TooltipTrigger: React.FC<TooltipTriggerProps> = ({
     if (
       offsetWidth &&
       window.innerWidth - x < offsetWidth &&
-      x - offsetWidth > pointerOffset
+      x - offsetWidth > pointerOffset &&
+      positionX !== "right"
     ) {
       offsetLeft = x - offsetWidth - (pointerOffset + 5);
     }
 
     // If tooltip doesn't have enough space on the bottom move it to the top right of the pointer.
-    if (offsetHeight && offsetHeight + y > window.innerHeight) {
+    if (
+      (offsetHeight && offsetHeight + y > window.innerHeight) ||
+      positionY === "top"
+    ) {
       offsetTop = y - offsetHeight - 15;
     }
 


### PR DESCRIPTION
## Description of the change

The `TooltipTrigger` component automatically positions the tooltip relative to the mouse position and the size of the tooltip. In some edge cases this leads to unwanted behavior: for instance, if the trigger component is very small, the tooltip will rapidly jump around. This PR adds a `positionX` and `positionY` prop that lets the parent lock in its position and override auto-positioning on each axis.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes [#XXXX]

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
