### PR TITLE
Move `styled-components` to peerDependencies

### DIFF
--- a/packages/design-system/CHANGELOG.md
+++ b/packages/design-system/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v5.9.0
+
+### Added
+
+- Moved `styled-components` into peerDependencies
+- Removed `react-is` from dependencies (we don't use it in this package)
+
 ## v5.8.0
 
 ### Added

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -34,16 +34,15 @@
     "body-scroll-lock": "^3.1.5",
     "polished": "^4.1.0",
     "prop-types": "^15.7.2",
-    "react-is": "^17.0.2",
     "react-modal": "^3.12.1",
     "react-spring": "^9.4.3",
     "react-tabs": "^3.2.2",
-    "react-toast-notifications": "^2.4.3",
-    "styled-components": "^5.2.1"
+    "react-toast-notifications": "^2.4.3"
   },
   "peerDependencies": {
     "react": "^17.0.0",
-    "react-dom": "^17.0.0"
+    "react-dom": "^17.0.0",
+    "styled-components": "^5.2.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
@@ -110,6 +109,7 @@
     "sass-loader": "^10.1.1",
     "semiotic": "^1.20.6",
     "style-loader": "^2.0.0",
+    "styled-components": "^5.2.1",
     "typescript": "^4.1.2",
     "yalc": "^1.0.0-pre.53"
   },

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recidiviz/design-system",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "description": "UI components and styles for Recidiviz web products.",
   "author": "Recidiviz <team@recidiviz.org>",
   "license": "GPL-3.0-only",


### PR DESCRIPTION
## Description of the change
When upgrading to Yarn v4 in `recidiviz-dashboards`, css styles started being applied in the wrong order. This is because the `@recidiviz/design-system` version of `styled-components` is being resolved differently from the  `recidiviz-dashboards` version of `styled-components`, resulting in this bug:  https://github.com/styled-components/styled-components/issues/3713

The simplest way to solve this is just make `styled-components` a `peerDependency` for this package so the user can guarantee a single `styled-components` will be used.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

> Closes [#XXXX]

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [ ] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
