### PR TITLE
[Design System] Allow Modal component to enable background scrolling

### DIFF
--- a/packages/design-system/CHANGELOG.md
+++ b/packages/design-system/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v5.10.0
+
+### Added
+
+- Optional `disableBackgroundScroll` prop to Modal component, true by default
+
 ## v5.9.0
 
 ### Added

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recidiviz/design-system",
-  "version": "5.9.0",
+  "version": "5.10.0",
   "description": "UI components and styles for Recidiviz web products.",
   "author": "Recidiviz <team@recidiviz.org>",
   "license": "GPL-3.0-only",

--- a/packages/design-system/src/components/Modal/Modal.stories.tsx
+++ b/packages/design-system/src/components/Modal/Modal.stories.tsx
@@ -40,6 +40,9 @@ export default {
       control: "boolean",
     },
     onRequestClose: { action: "requested close" },
+    disableBackgroundScroll: {
+      table: { disable: true },
+    },
     as: { table: { disable: true } },
     className: { table: { disable: true } },
     theme: { table: { disable: true } },
@@ -89,7 +92,9 @@ const Template: Story<ModalProps> = ({ isOpen, onRequestClose }) => (
       <ModalHeading>This is a modal.</ModalHeading>
       <Description>
         The background should not scroll while this modal is open; when the
-        modal is closed, it should scroll freely up and down.
+        modal is closed, it should scroll freely up and down. Background
+        scrolling can be enabled by setting the disableBackgroundScroll prop to
+        false.
       </Description>
     </ModalComponent>
   </TexturedBackground>

--- a/packages/design-system/src/components/Modal/Modal.tsx
+++ b/packages/design-system/src/components/Modal/Modal.tsx
@@ -28,6 +28,7 @@ ReactModal.defaultStyles.overlay = {};
 
 export interface ModalProps extends ReactModal.Props {
   className?: string;
+  disableBackgroundScroll?: boolean;
 }
 
 export const ModalHeading = styled.h3`
@@ -41,6 +42,7 @@ const UnstyledModal: React.FC<ModalProps> = ({
   onAfterOpen,
   onAfterClose,
   contentRef,
+  disableBackgroundScroll = true,
   ...rest
 }) => {
   const modalContentRef = React.useRef<HTMLDivElement | null>(null);
@@ -54,7 +56,7 @@ const UnstyledModal: React.FC<ModalProps> = ({
         if (node) modalContentRef.current = node;
       }}
       onAfterClose={() => {
-        if (modalContentRef.current) {
+        if (modalContentRef.current && disableBackgroundScroll) {
           enableBodyScroll(modalContentRef.current);
         }
         if (onAfterClose) {
@@ -62,7 +64,7 @@ const UnstyledModal: React.FC<ModalProps> = ({
         }
       }}
       onAfterOpen={(opts) => {
-        if (modalContentRef.current) {
+        if (modalContentRef.current && disableBackgroundScroll) {
           disableBodyScroll(modalContentRef.current);
         }
         if (onAfterOpen) {

--- a/packages/design-system/src/components/Modal/Modal.tsx
+++ b/packages/design-system/src/components/Modal/Modal.tsx
@@ -82,8 +82,11 @@ const UnstyledModal: React.FC<ModalProps> = ({
  * This component is a wrapper around the
  * [React Modal]({https://www.npmjs.com/package/react-modal) package.
  * It expects to be controlled by its parent component.
+ *
  * It will dim and blur the page behind it while open, and prevent the page from scrolling
  * using the [Body Scroll Lock](https://www.npmjs.com/package/body-scroll-lock) package.
+ * To override these settings, apply different styles to `.ReactModal__Overlay` and
+ * set the `disableBackgroundScroll` prop to `false`, respectively.
  *
  * The `isOpen` prop controls modal visibility, and the `onRequestClose`
  * prop is a hook that should set `isOpen` to `false`.


### PR DESCRIPTION
## Description of the change

Add a `disableBackgroundScroll` prop to the Modal component in the design system, which is `true` by default but prevents background scroll from being locked when it is `false`.

This will enable us to implement new designs in Workflows for the opportunity side panel. This side panel uses the DrawerModal component, which inherits from Modal. We would now like the user to be able to interact with the rest of the page while the modal is open; see https://github.com/Recidiviz/recidiviz-dashboards/pull/7280

Is it better to bump the version number in this PR or a separate one?

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

https://github.com/Recidiviz/recidiviz-dashboards/issues/7185

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
