### PR TITLE
[Design System] Handle menu items with tooltips

### DIFF
--- a/packages/design-system/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.stories.tsx
@@ -18,6 +18,7 @@ import * as React from "react";
 import { Meta, Story } from "@storybook/react";
 import { Dropdown } from "./Dropdown";
 import { ToastProvider, useToasts } from "../Toast";
+import { TooltipTrigger } from "../Tooltip";
 import { IconSVG } from "../Icon";
 import { DropdownToggle, DropdownToggleProps } from "./DropdownToggle";
 import { DropdownMenu, DropdownMenuProps } from "./DropdownMenu";
@@ -103,10 +104,12 @@ const Template: Story<CombinedArgs> = ({
             label="14 days"
             onClick={() => addToast("14 days")}
           />
-          <DropdownMenuItem
-            label="30 days"
-            onClick={() => addToast("30 days")}
-          />
+          <TooltipTrigger contents="One Month">
+            <DropdownMenuItem
+              label="30 days"
+              onClick={() => addToast("30 days")}
+            />
+          </TooltipTrigger>
           <DropdownMenuLabel>Other Actions</DropdownMenuLabel>
           <DropdownMenuItem onClick={() => addToast("Recidiviz")}>
             Say “Recidiviz”

--- a/packages/design-system/src/components/Dropdown/Dropdown.styles.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.styles.tsx
@@ -96,7 +96,6 @@ export const MenuElement = styled.div.attrs({
   role: "menubar",
 })<MenuElementProps>`
   ${typography.Sans14}
-  display: flex;
   flex-direction: column;
   position: absolute;
   min-width: 193px;
@@ -116,10 +115,12 @@ export const MenuElement = styled.div.attrs({
   opacity: 0;
   pointer-events: none;
   transform: translateY(-25%);
+  display: none;
 
   ${(props: MenuElementProps) =>
     props.shown &&
     css`
+      display: flex;
       z-index: 1;
       opacity: 1;
       pointer-events: all;

--- a/packages/design-system/src/components/Dropdown/Dropdown.styles.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.styles.tsx
@@ -96,7 +96,6 @@ export const MenuElement = styled.div.attrs({
   role: "menubar",
 })<MenuElementProps>`
   ${typography.Sans14}
-  flex-direction: column;
   position: absolute;
   min-width: 193px;
   padding: 0;
@@ -121,6 +120,7 @@ export const MenuElement = styled.div.attrs({
     props.shown &&
     css`
       display: flex;
+      flex-direction: column;
       z-index: 1;
       opacity: 1;
       pointer-events: all;


### PR DESCRIPTION
## Description of the change

Sets `display: none` when `DropdownMenu` is closed, so that we don't trigger menu item tooltips when menu is closed.

In IA, we wanted to add some tooltips to a menu button's dropdown items and noticed that the hover state was being triggered even when the menu was closed. See that conversation [here](https://github.com/Recidiviz/recidiviz-dashboards/pull/8805#pullrequestreview-2951726926). I am not sure of the history of the Dropdown components but I think `display: none` when closed should be ok. Confirmed the behavior is fixed via stories.

<Details><Summary>Screen recordings for a visual:</Summary>
Before:


https://github.com/user-attachments/assets/a3abdb22-a338-40b1-8324-f52d91fdf136




After:

https://github.com/user-attachments/assets/77a2c5b7-6bd6-4cde-badb-41e3c2edeb4d


</Details>

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

[recidiviz-dashboards/8669](https://github.com/Recidiviz/recidiviz-dashboards/issues/8669)

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing against realistic data has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
